### PR TITLE
feat(ideas): génération d'idées via l'API Mistral

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -63,3 +63,11 @@ MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 ###> nelmio/cors-bundle ###
 CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 ###< nelmio/cors-bundle ###
+
+###> mistral ###
+# Clé API Mistral pour la génération d'idées (POST /api/ideas/generate).
+# Laisser vide ici (placeholder) et définir la vraie clé dans .env.local
+# (qui est gitignoré). Sans clé valide, l'endpoint renvoie 503.
+MISTRAL_API_KEY=
+MISTRAL_MODEL=mistral-small-latest
+###< mistral ###

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -20,6 +20,7 @@
         "symfony/dotenv": "7.1.*",
         "symfony/flex": "^2",
         "symfony/framework-bundle": "7.1.*",
+        "symfony/http-client": "7.1.*",
         "symfony/mailer": "7.1.*",
         "symfony/messenger": "7.1.*",
         "symfony/property-access": "7.1.*",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11a8b285e9a8cb6cd78c186ff8e3122a",
+    "content-hash": "e9c566da0a47290a7b0fe81a58fced9d",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -2963,6 +2963,182 @@
                 }
             ],
             "time": "2025-01-29T07:13:42+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v7.1.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "71632c1f13b36cb4c23ccdd255946dc02753afef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/71632c1f13b36cb4c23ccdd255946dc02753afef",
+                "reference": "71632c1f13b36cb4c23ccdd255946dc02753afef",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-client-contracts": "~3.4.4|^3.5.2",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "php-http/discovery": "<1.15",
+                "symfony/http-foundation": "<6.4"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "3.0"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.5",
+                "amphp/http-client": "^4.2.1",
+                "amphp/http-tunnel": "^1.0",
+                "amphp/socket": "^1.1",
+                "guzzlehttp/promises": "^1.4|^2.0",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/rate-limiter": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v7.1.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-28T15:50:57+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-06T13:17:50+00:00"
         },
         {
             "name": "symfony/http-foundation",

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -22,3 +22,8 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+
+    App\Service\MistralIdeaGeneratorService:
+        arguments:
+            $apiKey: '%env(MISTRAL_API_KEY)%'
+            $model: '%env(MISTRAL_MODEL)%'

--- a/backend/src/Controller/Api/IdeaController.php
+++ b/backend/src/Controller/Api/IdeaController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Controller\ApiAbstractController;
+use App\Service\JwtAuthService;
+use App\Service\MistralGenerationException;
+use App\Service\MistralIdeaGeneratorService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/api/ideas')]
+class IdeaController extends ApiAbstractController
+{
+    private const ALLOWED_CONTENT_TYPES = ['blog', 'guide', 'listicle', 'tutorial', 'case-study'];
+    private const ALLOWED_LOCALES = ['fr', 'en'];
+    private const KEYWORD_MIN = 2;
+    private const KEYWORD_MAX = 120;
+    private const AUDIENCE_MAX = 500;
+
+    public function __construct(
+        private readonly JwtAuthService $jwtAuth,
+        private readonly MistralIdeaGeneratorService $generator,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    #[Route('/generate', name: 'api_ideas_generate', methods: ['POST'])]
+    public function generate(Request $request): JsonResponse
+    {
+        $user = $this->jwtAuth->authenticate($request);
+        if (!$user) {
+            return $this->json(['error' => 'Non authentifié.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $raw = $request->getContent();
+        $data = json_decode($raw, true);
+        if (!is_array($data)) {
+            return $this->json(['error' => 'Corps de requête JSON invalide.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $keyword = isset($data['keyword']) && is_string($data['keyword']) ? trim($data['keyword']) : '';
+        $keywordLength = mb_strlen($keyword);
+        if ($keywordLength < self::KEYWORD_MIN || $keywordLength > self::KEYWORD_MAX) {
+            return $this->json(
+                ['error' => 'Le mot-clé principal doit contenir entre ' . self::KEYWORD_MIN . ' et ' . self::KEYWORD_MAX . ' caractères.'],
+                Response::HTTP_BAD_REQUEST,
+            );
+        }
+
+        $contentType = null;
+        if (isset($data['contentType']) && is_string($data['contentType']) && $data['contentType'] !== '') {
+            $contentType = trim($data['contentType']);
+            if (!in_array($contentType, self::ALLOWED_CONTENT_TYPES, true)) {
+                return $this->json(['error' => 'Type de contenu invalide.'], Response::HTTP_BAD_REQUEST);
+            }
+        }
+
+        $audience = null;
+        if (isset($data['audience']) && is_string($data['audience']) && trim($data['audience']) !== '') {
+            $audience = trim($data['audience']);
+            if (mb_strlen($audience) > self::AUDIENCE_MAX) {
+                return $this->json(
+                    ['error' => 'L\'audience cible ne doit pas dépasser ' . self::AUDIENCE_MAX . ' caractères.'],
+                    Response::HTTP_BAD_REQUEST,
+                );
+            }
+        }
+
+        $locale = 'fr';
+        if (isset($data['locale']) && is_string($data['locale']) && in_array($data['locale'], self::ALLOWED_LOCALES, true)) {
+            $locale = $data['locale'];
+        }
+
+        try {
+            $ideas = $this->generator->generate($keyword, $contentType, $audience, $locale);
+        } catch (MistralGenerationException $e) {
+            $status = $e->getCode() >= 400 && $e->getCode() < 600 ? $e->getCode() : Response::HTTP_BAD_GATEWAY;
+            return $this->json(['error' => $e->getMessage()], $status);
+        } catch (\Throwable $e) {
+            $this->logger->error('Erreur inattendue lors de la génération d\'idées.', ['exception' => $e->getMessage()]);
+            return $this->json(['error' => 'Erreur interne lors de la génération.'], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return $this->json(['ideas' => $ideas]);
+    }
+}

--- a/backend/src/Service/MistralGenerationException.php
+++ b/backend/src/Service/MistralGenerationException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Service;
+
+/**
+ * Exception métier levée par MistralIdeaGeneratorService lorsque la génération échoue.
+ * Le code HTTP suggéré pour la réponse API est porté par $code (502 ou 503).
+ */
+class MistralGenerationException extends \RuntimeException
+{
+    public function __construct(string $message, int $httpStatus = 502, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, $httpStatus, $previous);
+    }
+}

--- a/backend/src/Service/MistralIdeaGeneratorService.php
+++ b/backend/src/Service/MistralIdeaGeneratorService.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace App\Service;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Génère des idées d'articles SEO via l'API Mistral (chat completions).
+ *
+ * Le service compose un prompt système + utilisateur en fonction du mot-clé,
+ * du type de contenu et de l'audience saisis, puis demande à Mistral de
+ * renvoyer un objet JSON strict { ideas: [...] }.
+ */
+class MistralIdeaGeneratorService
+{
+    public const ENDPOINT = 'https://api.mistral.ai/v1/chat/completions';
+
+    private const ALLOWED_DIFFICULTIES = ['easy', 'medium', 'advanced'];
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly LoggerInterface $logger,
+        private readonly string $apiKey,
+        private readonly string $model,
+    ) {}
+
+    public function isConfigured(): bool
+    {
+        return $this->apiKey !== '';
+    }
+
+    /**
+     * Génère une liste d'idées via Mistral.
+     *
+     * @return array<int, array{title:string, description:string, keywords:array<int,string>, difficulty:string, volume:string}>
+     *
+     * @throws MistralGenerationException si l'appel ou le parsing échoue
+     */
+    public function generate(
+        string $keyword,
+        ?string $contentType,
+        ?string $audience,
+        string $locale,
+    ): array {
+        if (!$this->isConfigured()) {
+            throw new MistralGenerationException('Le service de génération n\'est pas configuré.', 503);
+        }
+
+        $payload = [
+            'model' => $this->model,
+            'temperature' => 0.7,
+            'response_format' => ['type' => 'json_object'],
+            'messages' => [
+                ['role' => 'system', 'content' => $this->buildSystemPrompt($locale)],
+                ['role' => 'user', 'content' => $this->buildUserPrompt($keyword, $contentType, $audience, $locale)],
+            ],
+        ];
+
+        try {
+            $response = $this->httpClient->request('POST', self::ENDPOINT, [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $this->apiKey,
+                    'Content-Type' => 'application/json',
+                    'Accept' => 'application/json',
+                ],
+                'json' => $payload,
+                'timeout' => 30,
+            ]);
+
+            $status = $response->getStatusCode();
+            if ($status >= 400) {
+                $this->logger->warning('Mistral a renvoyé un statut HTTP non OK.', [
+                    'status' => $status,
+                    'body' => substr($response->getContent(false), 0, 500),
+                ]);
+                throw new MistralGenerationException('La génération a échoué côté fournisseur.', 502);
+            }
+
+            $data = $response->toArray(false);
+        } catch (HttpClientExceptionInterface $e) {
+            $this->logger->error('Erreur HTTP lors de l\'appel à Mistral.', ['exception' => $e->getMessage()]);
+            throw new MistralGenerationException('Service de génération injoignable.', 502, $e);
+        }
+
+        $content = $data['choices'][0]['message']['content'] ?? null;
+        if (!is_string($content) || $content === '') {
+            throw new MistralGenerationException('Réponse Mistral vide.', 502);
+        }
+
+        $decoded = json_decode($content, true);
+        if (!is_array($decoded) || !isset($decoded['ideas']) || !is_array($decoded['ideas'])) {
+            $this->logger->warning('Réponse Mistral non parsable.', ['content' => substr($content, 0, 500)]);
+            throw new MistralGenerationException('Réponse Mistral invalide.', 502);
+        }
+
+        $ideas = [];
+        foreach ($decoded['ideas'] as $raw) {
+            $normalized = $this->normalizeIdea($raw);
+            if ($normalized !== null) {
+                $ideas[] = $normalized;
+            }
+        }
+
+        if ($ideas === []) {
+            throw new MistralGenerationException('Aucune idée exploitable retournée.', 502);
+        }
+
+        return $ideas;
+    }
+
+    private function buildSystemPrompt(string $locale): string
+    {
+        if ($locale === 'en') {
+            return <<<PROMPT
+You are an SEO strategist. Generate practical, original content ideas tailored to the user request.
+Reply with a STRICT JSON object matching exactly:
+{"ideas":[{"title":string,"description":string,"keywords":[string,...],"difficulty":"easy"|"medium"|"advanced","volume":string}]}
+- "ideas" must contain between 4 and 6 items.
+- "description" must be 1 to 2 sentences.
+- "keywords" must contain between 2 and 5 short SEO keywords (no hashtags).
+- "volume" must be an estimated monthly search volume like "2.4K" or "850".
+Do not wrap the JSON in backticks. Do not add any text outside the JSON.
+PROMPT;
+        }
+
+        return <<<PROMPT
+Tu es un stratège SEO. Génère des idées de contenu pratiques et originales adaptées à la demande.
+Réponds avec un objet JSON STRICT correspondant exactement à :
+{"ideas":[{"title":string,"description":string,"keywords":[string,...],"difficulty":"easy"|"medium"|"advanced","volume":string}]}
+- "ideas" doit contenir entre 4 et 6 éléments.
+- "description" doit faire 1 à 2 phrases.
+- "keywords" doit contenir entre 2 et 5 mots-clés SEO courts (pas de hashtags).
+- "volume" doit être une estimation de volume de recherche mensuel comme "2.4K" ou "850".
+N'encadre pas le JSON avec des backticks. N'ajoute aucun texte en dehors du JSON.
+PROMPT;
+    }
+
+    private function buildUserPrompt(string $keyword, ?string $contentType, ?string $audience, string $locale): string
+    {
+        $isEn = $locale === 'en';
+        $lines = [];
+        $lines[] = $isEn ? 'Main keyword: ' . $keyword : 'Mot-clé principal : ' . $keyword;
+        if ($contentType !== null && $contentType !== '') {
+            $lines[] = $isEn ? 'Preferred content type: ' . $contentType : 'Type de contenu préféré : ' . $contentType;
+        }
+        if ($audience !== null && $audience !== '') {
+            $lines[] = $isEn ? 'Target audience: ' . $audience : 'Audience cible : ' . $audience;
+        }
+        $lines[] = $isEn
+            ? 'Language for the generated titles and descriptions: English.'
+            : 'Langue des titres et descriptions générés : français.';
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param mixed $raw
+     * @return array{title:string, description:string, keywords:array<int,string>, difficulty:string, volume:string}|null
+     */
+    private function normalizeIdea(mixed $raw): ?array
+    {
+        if (!is_array($raw)) {
+            return null;
+        }
+
+        $title = isset($raw['title']) && is_string($raw['title']) ? trim($raw['title']) : '';
+        $description = isset($raw['description']) && is_string($raw['description']) ? trim($raw['description']) : '';
+        if ($title === '' || $description === '') {
+            return null;
+        }
+
+        $keywords = [];
+        if (isset($raw['keywords']) && is_array($raw['keywords'])) {
+            foreach ($raw['keywords'] as $kw) {
+                if (is_string($kw)) {
+                    $trimmed = trim($kw);
+                    if ($trimmed !== '') {
+                        $keywords[] = $trimmed;
+                    }
+                }
+            }
+        }
+
+        $difficulty = isset($raw['difficulty']) && is_string($raw['difficulty'])
+            ? strtolower(trim($raw['difficulty']))
+            : 'medium';
+        if (!in_array($difficulty, self::ALLOWED_DIFFICULTIES, true)) {
+            $difficulty = 'medium';
+        }
+
+        $volume = isset($raw['volume']) && is_string($raw['volume']) ? trim($raw['volume']) : '';
+        if ($volume === '') {
+            $volume = '—';
+        }
+
+        return [
+            'title' => mb_substr($title, 0, 250),
+            'description' => mb_substr($description, 0, 600),
+            'keywords' => array_slice($keywords, 0, 5),
+            'difficulty' => $difficulty,
+            'volume' => mb_substr($volume, 0, 20),
+        ];
+    }
+}

--- a/frontend/src/app/ideas/page.jsx
+++ b/frontend/src/app/ideas/page.jsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { useSession } from "next-auth/react";
 import { Copy, RefreshCw, Sparkles, ThumbsDown, ThumbsUp } from "lucide-react";
 import { toast } from "sonner";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/Card";
@@ -10,6 +11,7 @@ import { Input } from "@/components/Input";
 import { Button } from "@/components/Button";
 import { Badge } from "@/components/Badge";
 import { useTranslation } from "@/hooks/useI18n";
+import { API_URL, Urls } from "@/utils/Api";
 
 const DIFFICULTY = {
     EASY: "easy",
@@ -17,52 +19,70 @@ const DIFFICULTY = {
     ADVANCED: "advanced",
 };
 
-const mockIdeas = [
-    {
-        titleKey: "ideas.mock.seoBeginners.title",
-        descriptionKey: "ideas.mock.seoBeginners.description",
-        keywords: ["SEO technique", "optimisation", "crawl budget"],
-        difficulty: DIFFICULTY.EASY,
-        volume: "2.4K",
-    },
-    {
-        titleKey: "ideas.mock.tenStrategies.title",
-        descriptionKey: "ideas.mock.tenStrategies.description",
-        keywords: ["content marketing", "stratégie digitale", "engagement"],
-        difficulty: DIFFICULTY.MEDIUM,
-        volume: "1.8K",
-    },
-    {
-        titleKey: "ideas.mock.aiImpact.title",
-        descriptionKey: "ideas.mock.aiImpact.description",
-        keywords: ["IA", "SEO", "automatisation"],
-        difficulty: DIFFICULTY.ADVANCED,
-        volume: "3.2K",
-    },
-    {
-        titleKey: "ideas.mock.metaDesc.title",
-        descriptionKey: "ideas.mock.metaDesc.description",
-        keywords: ["meta description", "CTR", "SERP"],
-        difficulty: DIFFICULTY.EASY,
-        volume: "1.5K",
-    },
-];
-
 const IdeaGenerator = () => {
-    const { t } = useTranslation();
+    const { t, locale } = useTranslation();
+    const { data: session } = useSession();
     const [keyword, setKeyword] = useState("");
     const [audience, setAudience] = useState("");
     const [contentType, setContentType] = useState("");
     const [ideas, setIdeas] = useState([]);
     const [isGenerating, setIsGenerating] = useState(false);
 
-    const handleGenerate = () => {
+    const handleGenerate = async () => {
+        const trimmedKeyword = keyword.trim();
+        if (trimmedKeyword.length < 2) {
+            toast.error(t("ideas.toast.errorMissingKeyword"));
+            return;
+        }
+        if (!session?.backendToken) {
+            toast.error(t("ideas.toast.errorNetwork"));
+            return;
+        }
+
         setIsGenerating(true);
-        setTimeout(() => {
-            setIdeas(mockIdeas);
+        try {
+            const res = await fetch(`${API_URL}${Urls.ideas.generate}`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${session.backendToken}`,
+                },
+                body: JSON.stringify({
+                    keyword: trimmedKeyword,
+                    contentType: contentType || undefined,
+                    audience: audience.trim() || undefined,
+                    locale,
+                }),
+            });
+
+            if (!res.ok) {
+                let message = t("ideas.toast.errorGeneration");
+                try {
+                    const data = await res.json();
+                    if (data?.error && typeof data.error === "string") {
+                        message = data.error;
+                    }
+                } catch {
+                    // body non JSON — message générique conservé
+                }
+                toast.error(message);
+                return;
+            }
+
+            const data = await res.json();
+            const list = Array.isArray(data?.ideas) ? data.ideas : [];
+            setIdeas(list);
+            if (list.length === 0) {
+                toast.error(t("ideas.toast.errorGeneration"));
+            } else {
+                toast.success(t("ideas.toast.generated"));
+            }
+        } catch (err) {
+            console.error("ideas.generate", err);
+            toast.error(t("ideas.toast.errorNetwork"));
+        } finally {
             setIsGenerating(false);
-            toast.success(t("ideas.toast.generated"));
-        }, 2000);
+        }
     };
 
     const handleCopy = (title) => {
@@ -76,6 +96,12 @@ const IdeaGenerator = () => {
             : d === DIFFICULTY.MEDIUM
                 ? "text-amber-600"
                 : "text-red-600";
+
+    const difficultyLabel = (d) => {
+        const key = `ideas.difficulty.${d}`;
+        const translated = t(key);
+        return translated === key ? d : translated;
+    };
 
     return (
         <div className="flex-1 overflow-auto bg-slate-50 dark:bg-slate-950 p-8">
@@ -99,6 +125,7 @@ const IdeaGenerator = () => {
                                     placeholder={t("ideas.mainKeywordPlaceholder")}
                                     value={keyword}
                                     onChange={(e) => setKeyword(e.target.value)}
+                                    maxLength={120}
                                 />
                             </div>
 
@@ -127,12 +154,13 @@ const IdeaGenerator = () => {
                                 value={audience}
                                 onChange={(e) => setAudience(e.target.value)}
                                 rows={3}
+                                maxLength={500}
                             />
                         </div>
 
                         <Button
                             onClick={handleGenerate}
-                            disabled={isGenerating || !keyword}
+                            disabled={isGenerating || keyword.trim().length < 2}
                             className="w-full md:w-auto"
                         >
                             {isGenerating ? (
@@ -150,7 +178,11 @@ const IdeaGenerator = () => {
                     </CardContent>
                 </Card>
 
-                {ideas.length > 0 && (
+                {ideas.length === 0 ? (
+                    <div className="rounded-md border border-dashed dark:border-slate-700 py-10 text-center text-sm text-slate-500 dark:text-slate-400">
+                        {t("ideas.empty")}
+                    </div>
+                ) : (
                     <div className="space-y-4">
                         <div className="flex items-center justify-between">
                             <h2 className="text-2xl">{t("ideas.suggestionsTitle")}</h2>
@@ -158,59 +190,58 @@ const IdeaGenerator = () => {
                         </div>
 
                         <div className="grid gap-6">
-                            {ideas.map((idea, index) => {
-                                const title = t(idea.titleKey);
-                                return (
-                                    <Card key={index} className="transition-shadow hover:shadow-md">
-                                        <CardHeader>
-                                            <div className="flex items-start justify-between gap-4">
-                                                <div className="flex-1 space-y-2">
-                                                    <CardTitle className="text-xl">{title}</CardTitle>
-                                                    <CardDescription>{t(idea.descriptionKey)}</CardDescription>
-                                                </div>
-                                                <Button
-                                                    variant="ghost"
-                                                    size="icon"
-                                                    onClick={() => handleCopy(title)}
-                                                >
-                                                    <Copy className="h-4 w-4" />
-                                                </Button>
+                            {ideas.map((idea, index) => (
+                                <Card key={index} className="transition-shadow hover:shadow-md">
+                                    <CardHeader>
+                                        <div className="flex items-start justify-between gap-4">
+                                            <div className="flex-1 space-y-2">
+                                                <CardTitle className="text-xl">{idea.title}</CardTitle>
+                                                <CardDescription>{idea.description}</CardDescription>
                                             </div>
-                                        </CardHeader>
-                                        <CardContent>
-                                            <div className="flex flex-wrap items-center gap-4">
-                                                <div className="flex flex-wrap gap-2">
-                                                    {idea.keywords.map((kw, kIndex) => (
-                                                        <Badge key={kIndex} variant="outline">
-                                                            {kw}
-                                                        </Badge>
-                                                    ))}
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                onClick={() => handleCopy(idea.title)}
+                                            >
+                                                <Copy className="h-4 w-4" />
+                                            </Button>
+                                        </div>
+                                    </CardHeader>
+                                    <CardContent>
+                                        <div className="flex flex-wrap items-center gap-4">
+                                            <div className="flex flex-wrap gap-2">
+                                                {(idea.keywords || []).map((kw, kIndex) => (
+                                                    <Badge key={kIndex} variant="outline">
+                                                        {kw}
+                                                    </Badge>
+                                                ))}
+                                            </div>
+                                            <div className="ml-auto flex items-center gap-4">
+                                                <div className="text-sm text-slate-600 dark:text-slate-400">
+                                                    <span className="font-medium">{t("ideas.difficultyLabel")}</span>{" "}
+                                                    <span className={difficultyColor(idea.difficulty)}>
+                                                        {difficultyLabel(idea.difficulty)}
+                                                    </span>
                                                 </div>
-                                                <div className="ml-auto flex items-center gap-4">
-                                                    <div className="text-sm text-slate-600 dark:text-slate-400">
-                                                        <span className="font-medium">{t("ideas.difficultyLabel")}</span>{" "}
-                                                        <span className={difficultyColor(idea.difficulty)}>
-                                                            {t(`ideas.difficulty.${idea.difficulty}`)}
-                                                        </span>
-                                                    </div>
+                                                {idea.volume && (
                                                     <div className="text-sm text-slate-600 dark:text-slate-400">
                                                         <span className="font-medium">{t("ideas.volumeLabel")}</span>{" "}
-                                                        {t("ideas.mock.volumeMonth", { value: idea.volume })}
+                                                        {t("ideas.volumeMonth", { value: idea.volume })}
                                                     </div>
-                                                    <div className="flex gap-1">
-                                                        <Button variant="ghost" size="icon">
-                                                            <ThumbsUp className="h-4 w-4" />
-                                                        </Button>
-                                                        <Button variant="ghost" size="icon">
-                                                            <ThumbsDown className="h-4 w-4" />
-                                                        </Button>
-                                                    </div>
+                                                )}
+                                                <div className="flex gap-1">
+                                                    <Button variant="ghost" size="icon">
+                                                        <ThumbsUp className="h-4 w-4" />
+                                                    </Button>
+                                                    <Button variant="ghost" size="icon">
+                                                        <ThumbsDown className="h-4 w-4" />
+                                                    </Button>
                                                 </div>
                                             </div>
-                                        </CardContent>
-                                    </Card>
-                                );
-                            })}
+                                        </div>
+                                    </CardContent>
+                                </Card>
+                            ))}
                         </div>
                     </div>
                 )}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -391,28 +391,14 @@
       "medium": "Medium",
       "advanced": "Advanced"
     },
+    "empty": "No ideas yet. Run a generation to get tailored suggestions.",
+    "volumeMonth": "{value}/month",
     "toast": {
       "generated": "Ideas generated successfully!",
-      "copied": "Title copied to clipboard"
-    },
-    "mock": {
-      "seoBeginners": {
-        "title": "Complete guide to technical SEO for beginners",
-        "description": "A detailed article covering the basics of technical SEO, including speed optimization, crawl budget, and URL structure."
-      },
-      "tenStrategies": {
-        "title": "10 content marketing strategies that work in 2026",
-        "description": "Discover proven tactics to create engaging, high-performing content in today's digital landscape."
-      },
-      "aiImpact": {
-        "title": "The impact of AI on SEO content creation",
-        "description": "An in-depth look at how artificial intelligence is transforming the way SEO-optimized content is produced."
-      },
-      "metaDesc": {
-        "title": "How to optimize your meta descriptions for CTR",
-        "description": "A practical guide to writing meta descriptions that increase your click-through rate in search results."
-      },
-      "volumeMonth": "{value}/month"
+      "copied": "Title copied to clipboard",
+      "errorMissingKeyword": "Main keyword is required (minimum 2 characters).",
+      "errorGeneration": "Generation failed. Please try again in a moment.",
+      "errorNetwork": "Network error during generation. Check your connection."
     }
   },
   "editor": {

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -391,28 +391,14 @@
       "medium": "Moyen",
       "advanced": "Avancé"
     },
+    "empty": "Aucune idée pour le moment. Lancez une génération pour obtenir des suggestions personnalisées.",
+    "volumeMonth": "{value}/mois",
     "toast": {
       "generated": "Idées générées avec succès !",
-      "copied": "Titre copié dans le presse-papier"
-    },
-    "mock": {
-      "seoBeginners": {
-        "title": "Guide complet du SEO technique pour les débutants",
-        "description": "Un article détaillé couvrant les bases du SEO technique, incluant l'optimisation de la vitesse, le crawl budget, et la structure des URLs."
-      },
-      "tenStrategies": {
-        "title": "10 stratégies de content marketing qui fonctionnent en 2026",
-        "description": "Découvrez les tactiques éprouvées pour créer du contenu engageant et performant dans l'environnement digital actuel."
-      },
-      "aiImpact": {
-        "title": "L'impact de l'IA sur la création de contenu SEO",
-        "description": "Analyse approfondie de comment l'intelligence artificielle transforme les pratiques de création de contenu optimisé pour les moteurs de recherche."
-      },
-      "metaDesc": {
-        "title": "Comment optimiser vos meta descriptions pour le CTR",
-        "description": "Guide pratique pour rédiger des meta descriptions qui augmentent votre taux de clics dans les résultats de recherche."
-      },
-      "volumeMonth": "{value}/mois"
+      "copied": "Titre copié dans le presse-papier",
+      "errorMissingKeyword": "Le mot-clé principal est requis (2 caractères minimum).",
+      "errorGeneration": "La génération a échoué. Réessayez dans quelques instants.",
+      "errorNetwork": "Erreur réseau lors de la génération. Vérifiez votre connexion."
     }
   },
   "editor": {

--- a/frontend/src/utils/Api.js
+++ b/frontend/src/utils/Api.js
@@ -8,5 +8,8 @@ export const Urls = {
   },
   user: {
       ips: '/user/ips',
-  }
+  },
+  ideas: {
+      generate: '/ideas/generate',
+  },
 };


### PR DESCRIPTION
## Résumé

La page `/ideas` du front affichait jusqu'ici 4 idées en dur (`mockIdeas`). Cette PR la branche sur un nouvel endpoint backend `POST /api/ideas/generate` qui interroge l'API Mistral (`mistral-small-latest`) pour produire une vraie liste d'idées d'articles SEO personnalisées en fonction du mot-clé, du type de contenu, de l'audience et de la langue UI.

## Type
- [x] `feat` — nouvelle fonctionnalité

## Scope
- [x] `fullstack`

## Surface touchée

### Backend
- [x] Controllers (`backend/src/Controller/Api/IdeaController.php`)
- [x] Services (`backend/src/Service/MistralIdeaGeneratorService.php`, `MistralGenerationException.php`)
- [x] Config (`backend/.env`, `backend/config/services.yaml`)
- [x] Dépendances (`backend/composer.json`, `composer.lock` — ajout `symfony/http-client`)

### Frontend
- [x] Pages (`frontend/src/app/ideas/page.jsx`)
- [x] Locales (`frontend/src/locales/{fr,en}.json` — ajout 5 clés, suppression bloc `ideas.mock.*`)
- [x] `utils/Api.js` (`Urls.ideas.generate`)

## Schéma Doctrine
- [x] Aucune modif

## Routes touchées

### Backend

| Méthode | URL | Controller | Auth | Note |
|---|---|---|---|---|
| POST | `/api/ideas/generate` | `Api\IdeaController::generate` | `JwtAuthService::authenticate` (pas d'ownership : endpoint non user-scoped) | Renvoie 401 sans JWT, 400 sur input invalide, 502 si Mistral fail, 503 si clé non configurée |

### Frontend

| Route | Type | Auth |
|---|---|---|
| `/ideas` | client (`"use client"`) | déjà dans le matcher de `proxy.js` ligne 14 — rien à ajouter |

## Bridge auth touché ?
- [x] Non

## Smoke tests joués

```bash
EMAIL=pipeline_a_1779043406@test.local
TOKEN=$(curl -s -X POST http://localhost:8000/api/auth/login -H "Content-Type: application/json" \
  -d "{\"email\":\"$EMAIL\",\"password\":\"changeme1\"}" | jq -r .token)

curl -X POST http://localhost:8000/api/ideas/generate \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"keyword":"SEO technique","contentType":"blog","audience":"développeurs web","locale":"fr"}'
# → HTTP 200 + { "ideas": [ 6 idées en français ] }
```

- ✅ Auth : 401 sans header, 401 header malformé, 200 cross-user (endpoint non user-scoped donc pas de vecteur IDOR)
- ✅ Validation : keyword absent/vide/<2/>120 chars → 400 ; contentType hors whitelist → 400 ; audience >500 chars → 400 ; JSON corrompu / body non-JSON / null byte → 400 (jamais 500)
- ✅ Sécurité : pas de `dangerouslySetInnerHTML` sur la sortie Mistral (XSS impossible via React) ; clé Mistral jamais commitée (`.env.local` gitignoré, `git diff | grep` sur la clé → 0 match) ; aucune SQL raw dans le nouveau code
- ✅ Edge cases : happy path FR (6 idées), happy path EN (idées en anglais selon `locale`), parsing défensif si Mistral renvoie du JSON malformé → 502 propre, empty state UI quand aucune idée générée
- ✅ i18n : 400 clés FR == 400 clés EN, parité vérifiée par script
- ✅ Dark mode : page conserve `bg-slate-50 dark:bg-slate-950` ; empty state `border dark:border-slate-700`

Rapport complet : voir commentaire de PR (à joindre).

## i18n
- [x] Clés ajoutées dans `frontend/src/locales/fr.json` ET `frontend/src/locales/en.json` simultanément
- Nouvelles clés : `ideas.empty`, `ideas.volumeMonth` (déplacée hors de `mock`), `ideas.toast.errorMissingKeyword`, `ideas.toast.errorGeneration`, `ideas.toast.errorNetwork`
- Clés supprimées : `ideas.mock.*` (4 titres + descriptions devenus inutiles maintenant que les idées viennent de Mistral). Aucune référence résiduelle (vérifié par `grep`).

## Theming
- [x] Page `/ideas` déjà en `bg-slate-50 dark:bg-slate-950` ; empty state ajoutée respecte `border dark:border-slate-700` + `text-slate-500 dark:text-slate-400`

## Mail
- [x] Aucun nouvel envoi

## Build & validations

- ✅ `php bin/console doctrine:schema:validate` — mapping files correct (le diff `messenger_messages` est préexistant, non introduit par cette PR — vérifié par `git diff` qui ne touche aucune entité)
- ⚠️ `cd frontend && npm run lint` — exit 1 mais **uniquement** sur erreurs préexistantes dans `app/page.jsx`, `context/LanguageContext.jsx`, `utils/Image.js` (non modifiés par cette PR)
- ⚠️ `cd frontend && npm run build` — non exécuté : dossier `.next/` owned root, pré-existant. Compilation validée via le dev server (route `/ideas` renvoie HTTP 307 = redirect auth, sans erreur de compile)
- N/A `doctrine:migrations:status` — aucune migration ajoutée

## Configuration requise

Avant de tester la PR, **chaque dev doit ajouter sa propre clé Mistral** dans `backend/.env.local` :

```bash
# backend/.env.local (gitignoré)
MISTRAL_API_KEY=<ta_clé_console.mistral.ai>
```

Sans clé, l'endpoint renvoie `503 { "error": "Le service de génération n'est pas configuré." }` (logique `MistralIdeaGeneratorService::isConfigured()`).

Le model par défaut (`mistral-small-latest`) est surchargeable via `MISTRAL_MODEL` si besoin.

## Rollback

```bash
git revert 3cb4e2e
# pas de migration à dérouler
```

## Points d'attention pour le reviewer

- `MistralIdeaGeneratorService.php:165–185` : `normalizeIdea()` accepte des entrées partielles (difficulty fallback à `medium`, volume fallback à `—`) plutôt que de tout rejeter. Décision : un format légèrement dégradé vaut mieux qu'une erreur 502 si Mistral oublie un champ.
- `IdeaController.php:73` : `locale` invalide est **silencieusement** rabattu sur `fr` plutôt que de renvoyer 400. C'est intentionnel — c'est un paramètre de confort UI, pas un input critique.
- `MistralIdeaGeneratorService.php:73` : timeout HTTP fixé à 30s. Mistral met typiquement 5-15s pour 6 idées ; 30s laisse de la marge sans bloquer indéfiniment.
- Pas de cache, pas de rate limiting côté backend : 1 appel UI = 1 appel Mistral. Le bouton « Générer » est `disabled` pendant `isGenerating` côté front, ce qui empêche le double-clic mais pas le spam multi-onglets. À durcir si l'usage le justifie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
