### PR TITLE
feat(google): intégration Google (Sign-In + Calendar)

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -71,3 +71,14 @@ CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 MISTRAL_API_KEY=
 MISTRAL_MODEL=mistral-small-latest
 ###< mistral ###
+
+###> google ###
+# Credentials OAuth Google (Sign-In + Calendar).
+# Créez un projet sur Google Cloud Console, activez Google People API et
+# Google Calendar API, créez un OAuth Client ID (Web application) avec :
+#   - Redirect URI : http://localhost:3000/api/auth/callback/google
+#   - Redirect URI : http://localhost:3000/auth/google-calendar/callback
+# Puis renseignez les vraies valeurs dans backend/.env.local (gitignoré).
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+###< google ###

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -32,3 +32,12 @@ services:
         arguments:
             $apiKey: '%env(MISTRAL_API_KEY)%'
             $model: '%env(MISTRAL_MODEL)%'
+
+    App\Service\GoogleAuthService:
+        arguments:
+            $googleClientId: '%env(default::GOOGLE_CLIENT_ID)%'
+
+    App\Service\GoogleCalendarService:
+        arguments:
+            $googleClientId: '%env(default::GOOGLE_CLIENT_ID)%'
+            $googleClientSecret: '%env(default::GOOGLE_CLIENT_SECRET)%'

--- a/backend/migrations/Version20260518094327.php
+++ b/backend/migrations/Version20260518094327.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260518094327 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajoute scheduled_at/google_event_id sur article + refresh_token/token_expires_at/scopes sur integration pour l\'intégration Google Calendar.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE article ADD scheduled_at DATETIME DEFAULT NULL, ADD google_event_id VARCHAR(64) DEFAULT NULL');
+        $this->addSql('CREATE INDEX idx_article_scheduled_at ON article (scheduled_at)');
+        $this->addSql('CREATE INDEX idx_article_google_event ON article (google_event_id)');
+        $this->addSql('ALTER TABLE integration ADD refresh_token LONGTEXT DEFAULT NULL, ADD token_expires_at DATETIME DEFAULT NULL, ADD scopes LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_article_scheduled_at ON article');
+        $this->addSql('DROP INDEX idx_article_google_event ON article');
+        $this->addSql('ALTER TABLE article DROP scheduled_at, DROP google_event_id');
+        $this->addSql('ALTER TABLE integration DROP refresh_token, DROP token_expires_at, DROP scopes');
+    }
+}

--- a/backend/src/Controller/Api/ArticleController.php
+++ b/backend/src/Controller/Api/ArticleController.php
@@ -7,6 +7,7 @@ use App\Entity\Article;
 use App\Entity\User;
 use App\Repository\ArticleRepository;
 use App\Repository\IntegrationRepository;
+use App\Service\GoogleCalendarService;
 use App\Service\JwtAuthService;
 use App\Service\MistralArticleService;
 use App\Service\MistralGenerationException;
@@ -40,6 +41,7 @@ class ArticleController extends ApiAbstractController
         private readonly LoggerInterface $logger,
         private readonly IntegrationRepository $integrationRepository,
         private readonly NotionService $notion,
+        private readonly GoogleCalendarService $calendar,
     ) {}
 
     #[Route('', name: 'api_articles_list', methods: ['GET'])]
@@ -390,6 +392,158 @@ class ArticleController extends ApiAbstractController
         ]);
     }
 
+    /**
+     * Planifie la publication d'un article : crée (ou met à jour) un event
+     * Google Calendar et persiste scheduledAt + googleEventId.
+     */
+    #[Route('/{id}/schedule', name: 'api_articles_schedule', methods: ['POST'], requirements: ['id' => '\d+'])]
+    public function schedule(int $id, Request $request): JsonResponse
+    {
+        $user = $this->jwtAuth->authenticate($request);
+        if (!$user) {
+            return $this->json(['error' => 'Non authentifié.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $article = $this->findOwned($id, $user);
+        if (!$article) {
+            return $this->json(['error' => 'Article introuvable.'], Response::HTTP_NOT_FOUND);
+        }
+
+        $integration = $this->integrationRepository->findOneByUserAndType($user, 'google');
+        if ($integration === null || !$integration->isActive()) {
+            return $this->json(['error' => 'Connectez d\'abord Google Calendar dans les paramètres.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $data = $this->decodeBody($request);
+        if ($data === null) {
+            return $this->json(['error' => 'Corps de requête JSON invalide.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $scheduledAt = $this->parseFutureDateTime($data['scheduledAt'] ?? null);
+        if ($scheduledAt === null) {
+            return $this->json(['error' => 'Date de publication invalide ou dans le passé.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $title = (string) ($article->getTitle() ?? '');
+        if (trim($title) === '') {
+            return $this->json(['error' => 'Donnez un titre à l\'article avant de planifier sa publication.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $summary = 'Publication : ' . $title;
+        $description = "Publication planifiée pour l'article #" . $article->getId();
+        $end = (clone $scheduledAt)->modify('+30 minutes');
+
+        try {
+            $existing = $article->getGoogleEventId();
+            if ($existing === null || $existing === '') {
+                $eventId = $this->calendar->createEvent($integration, $summary, $description, $scheduledAt, $end);
+                $article->setGoogleEventId($eventId);
+            } else {
+                try {
+                    $this->calendar->updateEvent($integration, $existing, $summary, $description, $scheduledAt, $end);
+                } catch (\RuntimeException $updateErr) {
+                    $this->logger->info('Update Calendar en échec, fallback création.', [
+                        'articleId' => $id,
+                        'eventId' => $existing,
+                        'message' => $updateErr->getMessage(),
+                    ]);
+                    $eventId = $this->calendar->createEvent($integration, $summary, $description, $scheduledAt, $end);
+                    $article->setGoogleEventId($eventId);
+                }
+            }
+            $article->setScheduledAt($scheduledAt);
+            $article->setUpdatedAt(new \DateTime());
+            $integration->setLastSync(new \DateTime());
+            $this->em->flush();
+        } catch (\RuntimeException $e) {
+            return $this->json(['error' => $e->getMessage()], Response::HTTP_BAD_GATEWAY);
+        } catch (\Throwable $e) {
+            $this->logger->error('Erreur inattendue lors du schedule Google.', [
+                'articleId' => $id,
+                'exception' => $e->getMessage(),
+            ]);
+            return $this->json(['error' => 'Impossible de planifier la publication.'], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return $this->json([
+            'scheduledAt' => $article->getScheduledAt()?->format('c'),
+            'googleEventId' => $article->getGoogleEventId(),
+        ]);
+    }
+
+    /**
+     * Crée un event Calendar one-shot "Rappel : <titre>" pour la relecture.
+     * Pas de tracking sur l'article (l'event vit dans le calendrier de l'user).
+     */
+    #[Route('/{id}/reminder', name: 'api_articles_reminder', methods: ['POST'], requirements: ['id' => '\d+'])]
+    public function reminder(int $id, Request $request): JsonResponse
+    {
+        $user = $this->jwtAuth->authenticate($request);
+        if (!$user) {
+            return $this->json(['error' => 'Non authentifié.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $article = $this->findOwned($id, $user);
+        if (!$article) {
+            return $this->json(['error' => 'Article introuvable.'], Response::HTTP_NOT_FOUND);
+        }
+
+        $integration = $this->integrationRepository->findOneByUserAndType($user, 'google');
+        if ($integration === null || !$integration->isActive()) {
+            return $this->json(['error' => 'Connectez d\'abord Google Calendar dans les paramètres.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $data = $this->decodeBody($request);
+        if ($data === null) {
+            return $this->json(['error' => 'Corps de requête JSON invalide.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $remindAt = $this->parseFutureDateTime($data['remindAt'] ?? null);
+        if ($remindAt === null) {
+            return $this->json(['error' => 'Date de rappel invalide ou dans le passé.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $title = (string) ($article->getTitle() ?? 'sans titre');
+        $summary = 'Rappel : relire « ' . $title . ' »';
+        $description = 'Rappel de relecture pour l\'article #' . $article->getId();
+        $end = (clone $remindAt)->modify('+15 minutes');
+
+        try {
+            $eventId = $this->calendar->createEvent($integration, $summary, $description, $remindAt, $end);
+            $integration->setLastSync(new \DateTime());
+            $this->em->flush();
+        } catch (\RuntimeException $e) {
+            return $this->json(['error' => $e->getMessage()], Response::HTTP_BAD_GATEWAY);
+        } catch (\Throwable $e) {
+            $this->logger->error('Erreur inattendue lors du reminder Google.', [
+                'articleId' => $id,
+                'exception' => $e->getMessage(),
+            ]);
+            return $this->json(['error' => 'Impossible de programmer le rappel.'], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return $this->json([
+            'eventId' => $eventId,
+            'remindAt' => $remindAt->format('c'),
+        ]);
+    }
+
+    private function parseFutureDateTime(mixed $raw): ?\DateTime
+    {
+        if (!is_string($raw) || trim($raw) === '') {
+            return null;
+        }
+        try {
+            $dt = new \DateTime($raw);
+        } catch (\Throwable) {
+            return null;
+        }
+        if ($dt <= new \DateTime()) {
+            return null;
+        }
+        return $dt;
+    }
+
     private function findOwned(int $id, User $user): ?Article
     {
         return $this->repository->findOneBy(['id' => $id, 'user' => $user]);
@@ -532,6 +686,8 @@ class ArticleController extends ApiAbstractController
             'updatedAt' => $article->getUpdatedAt()?->format('c'),
             'publishedAt' => $article->getPublishedAt()?->format('c'),
             'notionPageId' => $article->getNotionPageId(),
+            'scheduledAt' => $article->getScheduledAt()?->format('c'),
+            'googleEventId' => $article->getGoogleEventId(),
         ];
     }
 }

--- a/backend/src/Controller/Api/AuthController.php
+++ b/backend/src/Controller/Api/AuthController.php
@@ -6,6 +6,7 @@ use App\Controller\ApiAbstractController;
 use App\Entity\User;
 use App\Event\UserRegisteredEvent;
 use App\Repository\UserRepository;
+use App\Service\GoogleAuthService;
 use App\Service\UserLoginIpRecorder;
 use Doctrine\ORM\EntityManagerInterface;
 use Firebase\JWT\JWT;
@@ -29,6 +30,7 @@ class AuthController extends ApiAbstractController
         private ParameterBagInterface $params,
         private EventDispatcherInterface $eventDispatcher,
         private UserLoginIpRecorder $loginIpRecorder,
+        private GoogleAuthService $googleAuth,
     ) {}
 
     #[Route('/signup', name: 'api_auth_signup', methods: ['POST'])]
@@ -139,6 +141,71 @@ class AuthController extends ApiAbstractController
     {
         return $this->json([
             'message' => 'Déconnexion réussie.',
+        ], Response::HTTP_OK);
+    }
+
+    /**
+     * Sign-In / Sign-Up Google. Reçoit un id_token Google, le vérifie via JWKS,
+     * crée le user s'il n'existe pas (avec un mot de passe aléatoire, jamais
+     * communiqué), et retourne le même shape { token, user } que /login.
+     */
+    #[Route('/google', name: 'api_auth_google', methods: ['POST'])]
+    public function google(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        if (!is_array($data) || !isset($data['idToken']) || !is_string($data['idToken']) || trim($data['idToken']) === '') {
+            return $this->json(['error' => 'idToken manquant.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $payload = $this->googleAuth->verifyIdToken(trim($data['idToken']));
+        } catch (\RuntimeException $e) {
+            return $this->json(['error' => $e->getMessage()], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $email = mb_strtolower(trim((string) $payload['email']));
+        $name = isset($payload['name']) && is_string($payload['name']) && trim($payload['name']) !== ''
+            ? trim($payload['name'])
+            : $email;
+        $avatar = isset($payload['picture']) && is_string($payload['picture']) ? $payload['picture'] : null;
+
+        $user = $this->userRepository->findOneBy(['email' => $email]);
+        if (!$user) {
+            $user = new User();
+            $user->setEmail($email);
+            $user->setName(mb_substr($name, 0, 100));
+            // Mot de passe aléatoire jamais communiqué : empêche le login local
+            // tant que le user n'a pas explicitement défini un mot de passe.
+            $user->setPassword(password_hash(bin2hex(random_bytes(32)), PASSWORD_BCRYPT));
+            if ($avatar !== null && mb_strlen($avatar) <= 1000) {
+                $user->setAvatar($avatar);
+            }
+
+            $errors = $this->validator->validate($user);
+            if (count($errors) > 0) {
+                $msg = [];
+                foreach ($errors as $err) {
+                    $msg[$err->getPropertyPath()] = $err->getMessage();
+                }
+                return $this->json(['errors' => $msg], Response::HTTP_UNPROCESSABLE_ENTITY);
+            }
+
+            $this->em->persist($user);
+            $this->em->flush();
+
+            $this->eventDispatcher->dispatch(new UserRegisteredEvent($user), UserRegisteredEvent::NAME);
+            $this->loginIpRecorder->record($user, $request, 'signup');
+        } else {
+            $this->loginIpRecorder->record($user, $request, 'login');
+        }
+
+        $user->setLastLogin(new \DateTime());
+        $this->em->flush();
+
+        return $this->json([
+            'message' => 'Connexion Google réussie.',
+            'token' => $this->generateJWT($user),
+            'user' => $this->serializeUser($user),
         ], Response::HTTP_OK);
     }
 

--- a/backend/src/Controller/Api/AuthController.php
+++ b/backend/src/Controller/Api/AuthController.php
@@ -157,8 +157,15 @@ class AuthController extends ApiAbstractController
             return $this->json(['error' => 'idToken manquant.'], Response::HTTP_BAD_REQUEST);
         }
 
+        $idToken = trim($data['idToken']);
+        // Les id_tokens Google légitimes font ~1-2 KB ; au-delà, c'est forcément
+        // invalide. Fail-fast avant l'appel JWKS qui ferait du réseau pour rien.
+        if (mb_strlen($idToken) > 4000) {
+            return $this->json(['error' => 'idToken Google trop long.'], Response::HTTP_BAD_REQUEST);
+        }
+
         try {
-            $payload = $this->googleAuth->verifyIdToken(trim($data['idToken']));
+            $payload = $this->googleAuth->verifyIdToken($idToken);
         } catch (\RuntimeException $e) {
             return $this->json(['error' => $e->getMessage()], Response::HTTP_UNAUTHORIZED);
         }

--- a/backend/src/Controller/Api/GoogleIntegrationController.php
+++ b/backend/src/Controller/Api/GoogleIntegrationController.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Controller\ApiAbstractController;
+use App\Entity\Integration;
+use App\Repository\ArticleRepository;
+use App\Repository\IntegrationRepository;
+use App\Service\GoogleCalendarService;
+use App\Service\JwtAuthService;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/api/integrations/google')]
+class GoogleIntegrationController extends ApiAbstractController
+{
+    private const TYPE = 'google';
+
+    public function __construct(
+        private readonly JwtAuthService $jwtAuth,
+        private readonly IntegrationRepository $integrationRepository,
+        private readonly ArticleRepository $articleRepository,
+        private readonly GoogleCalendarService $calendar,
+        private readonly EntityManagerInterface $em,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Statut de la connexion Google du user, sans jamais exposer les tokens.
+     */
+    #[Route('', name: 'api_integrations_google_read', methods: ['GET'])]
+    public function read(Request $request): JsonResponse
+    {
+        $user = $this->jwtAuth->authenticate($request);
+        if (!$user) {
+            return $this->json(['error' => 'Non authentifié.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $integration = $this->integrationRepository->findOneByUserAndType($user, self::TYPE);
+
+        return $this->json([
+            'connected' => $integration !== null && $integration->isActive(),
+            'scopes' => $integration?->getScopes(),
+            'lastSync' => $integration?->getLastSync()?->format('c'),
+            'tokenExpiresAt' => $integration?->getTokenExpiresAt()?->format('c'),
+        ]);
+    }
+
+    /**
+     * Échange le code OAuth Google contre des tokens et persiste l'intégration.
+     * Appelé par la page front /auth/google-calendar/callback.
+     */
+    #[Route('/calendar/connect', name: 'api_integrations_google_calendar_connect', methods: ['POST'])]
+    public function connectCalendar(Request $request): JsonResponse
+    {
+        $user = $this->jwtAuth->authenticate($request);
+        if (!$user) {
+            return $this->json(['error' => 'Non authentifié.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        if (!is_array($data)) {
+            return $this->json(['error' => 'Corps de requête JSON invalide.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $code = is_string($data['code'] ?? null) ? trim($data['code']) : '';
+        $redirectUri = is_string($data['redirectUri'] ?? null) ? trim($data['redirectUri']) : '';
+
+        if ($code === '' || mb_strlen($code) > 2000) {
+            return $this->json(['error' => 'Code OAuth Google manquant ou invalide.'], Response::HTTP_BAD_REQUEST);
+        }
+        if ($redirectUri === '' || mb_strlen($redirectUri) > 500) {
+            return $this->json(['error' => 'redirectUri manquant ou invalide.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $tokens = $this->calendar->exchangeCode($code, $redirectUri);
+        } catch (\RuntimeException $e) {
+            return $this->json(['error' => $e->getMessage()], Response::HTTP_BAD_GATEWAY);
+        }
+
+        try {
+            $integration = $this->integrationRepository->findOneByUserAndType($user, self::TYPE);
+            if ($integration === null) {
+                $integration = new Integration();
+                $integration->setUser($user);
+                $integration->setType(self::TYPE);
+                $this->em->persist($integration);
+            }
+
+            $integration->setApiKey($tokens['access_token']);
+            // Le refresh_token n'est renvoyé qu'à la première autorisation (ou si prompt=consent).
+            // S'il manque, on garde l'ancien (cas re-connexion sans prompt=consent).
+            if ($tokens['refresh_token'] !== null) {
+                $integration->setRefreshToken($tokens['refresh_token']);
+            }
+            $integration->setTokenExpiresAt(
+                (new \DateTime())->modify('+' . $tokens['expires_in'] . ' seconds')
+            );
+            $integration->setScopes($tokens['scope']);
+            $integration->setActive(true);
+            $this->em->flush();
+        } catch (\Throwable $e) {
+            $this->logger->error('Échec de persistance de l\'intégration Google.', [
+                'userId' => $user->getId(),
+                'exception' => $e->getMessage(),
+            ]);
+            return $this->json(['error' => 'Impossible d\'enregistrer la connexion Google.'], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return $this->json([
+            'connected' => true,
+            'scopes' => $integration->getScopes(),
+            'lastSync' => $integration->getLastSync()?->format('c'),
+            'tokenExpiresAt' => $integration->getTokenExpiresAt()?->format('c'),
+        ]);
+    }
+
+    /**
+     * Déconnecte l'intégration Google : supprime l'Integration et nettoie
+     * les google_event_id des articles du user.
+     */
+    #[Route('', name: 'api_integrations_google_disconnect', methods: ['DELETE'])]
+    public function disconnect(Request $request): JsonResponse
+    {
+        $user = $this->jwtAuth->authenticate($request);
+        if (!$user) {
+            return $this->json(['error' => 'Non authentifié.'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $integration = $this->integrationRepository->findOneByUserAndType($user, self::TYPE);
+        if ($integration === null) {
+            return $this->json(null, Response::HTTP_NO_CONTENT);
+        }
+
+        try {
+            $this->articleRepository->createQueryBuilder('a')
+                ->update()
+                ->set('a.googleEventId', ':null')
+                ->where('a.user = :user')
+                ->andWhere('a.googleEventId IS NOT NULL')
+                ->setParameter('null', null)
+                ->setParameter('user', $user)
+                ->getQuery()
+                ->execute();
+
+            $this->em->remove($integration);
+            $this->em->flush();
+        } catch (\Throwable $e) {
+            $this->logger->error('Échec de déconnexion Google.', [
+                'userId' => $user->getId(),
+                'exception' => $e->getMessage(),
+            ]);
+            return $this->json(['error' => 'Impossible de déconnecter Google.'], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return $this->json(null, Response::HTTP_NO_CONTENT);
+    }
+}

--- a/backend/src/Entity/Article.php
+++ b/backend/src/Entity/Article.php
@@ -10,6 +10,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(name: 'idx_article_user', columns: ['user_id'])]
 #[ORM\Index(name: 'idx_article_user_status', columns: ['user_id', 'status'])]
 #[ORM\Index(name: 'idx_article_notion_page', columns: ['notion_page_id'])]
+#[ORM\Index(name: 'idx_article_scheduled_at', columns: ['scheduled_at'])]
+#[ORM\Index(name: 'idx_article_google_event', columns: ['google_event_id'])]
 class Article
 {
     public const STATUS_DRAFT = 'draft';
@@ -81,6 +83,12 @@ class Article
 
     #[ORM\Column(length: 36, nullable: true)]
     private ?string $notionPageId = null;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    private ?\DateTimeInterface $scheduledAt = null;
+
+    #[ORM\Column(length: 64, nullable: true)]
+    private ?string $googleEventId = null;
 
     public function __construct()
     {
@@ -272,6 +280,28 @@ class Article
     public function setNotionPageId(?string $notionPageId): static
     {
         $this->notionPageId = $notionPageId;
+        return $this;
+    }
+
+    public function getScheduledAt(): ?\DateTimeInterface
+    {
+        return $this->scheduledAt;
+    }
+
+    public function setScheduledAt(?\DateTimeInterface $scheduledAt): static
+    {
+        $this->scheduledAt = $scheduledAt;
+        return $this;
+    }
+
+    public function getGoogleEventId(): ?string
+    {
+        return $this->googleEventId;
+    }
+
+    public function setGoogleEventId(?string $googleEventId): static
+    {
+        $this->googleEventId = $googleEventId;
         return $this;
     }
 }

--- a/backend/src/Entity/Integration.php
+++ b/backend/src/Entity/Integration.php
@@ -33,6 +33,15 @@ class Integration
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $lastSync = null;
 
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $refreshToken = null;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    private ?\DateTimeInterface $tokenExpiresAt = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $scopes = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -104,6 +113,39 @@ class Integration
     public function setLastSync(?\DateTimeInterface $lastSync): static
     {
         $this->lastSync = $lastSync;
+        return $this;
+    }
+
+    public function getRefreshToken(): ?string
+    {
+        return $this->refreshToken;
+    }
+
+    public function setRefreshToken(?string $refreshToken): static
+    {
+        $this->refreshToken = $refreshToken;
+        return $this;
+    }
+
+    public function getTokenExpiresAt(): ?\DateTimeInterface
+    {
+        return $this->tokenExpiresAt;
+    }
+
+    public function setTokenExpiresAt(?\DateTimeInterface $tokenExpiresAt): static
+    {
+        $this->tokenExpiresAt = $tokenExpiresAt;
+        return $this;
+    }
+
+    public function getScopes(): ?string
+    {
+        return $this->scopes;
+    }
+
+    public function setScopes(?string $scopes): static
+    {
+        $this->scopes = $scopes;
         return $this;
     }
 }

--- a/backend/src/Service/GoogleAuthService.php
+++ b/backend/src/Service/GoogleAuthService.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Service;
+
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Vérifie un id_token Google en validant sa signature contre les clés
+ * publiques de Google (JWKS) et en contrôlant aud/iss/exp.
+ *
+ * @see https://developers.google.com/identity/sign-in/web/backend-auth
+ */
+class GoogleAuthService
+{
+    private const JWKS_URL = 'https://www.googleapis.com/oauth2/v3/certs';
+    private const ALLOWED_ISSUERS = ['accounts.google.com', 'https://accounts.google.com'];
+    private const CACHE_KEY = 'google_jwks_v3';
+    private const CACHE_TTL = 3600; // 1h
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly LoggerInterface $logger,
+        private readonly CacheInterface $cache,
+        private readonly string $googleClientId,
+    ) {}
+
+    /**
+     * Vérifie l'id_token et retourne le payload décodé.
+     *
+     * @throws \RuntimeException si le token est invalide pour quelque raison que ce soit
+     * @return array{sub:string, email:string, email_verified?:bool, name?:string, picture?:string, iss:string, aud:string, exp:int}
+     */
+    public function verifyIdToken(string $idToken): array
+    {
+        if ($this->googleClientId === '') {
+            throw new \RuntimeException('GOOGLE_CLIENT_ID non configuré côté backend.');
+        }
+
+        $keys = $this->fetchJwks();
+
+        try {
+            $decoded = JWT::decode($idToken, $keys);
+        } catch (\Throwable $e) {
+            $this->logger->warning('Échec de décodage de l\'id_token Google.', ['exception' => $e->getMessage()]);
+            throw new \RuntimeException('id_token Google invalide.', previous: $e);
+        }
+
+        $payload = (array) $decoded;
+
+        if (!isset($payload['iss']) || !in_array($payload['iss'], self::ALLOWED_ISSUERS, true)) {
+            throw new \RuntimeException('Émetteur (iss) de l\'id_token Google invalide.');
+        }
+        if (!isset($payload['aud']) || $payload['aud'] !== $this->googleClientId) {
+            throw new \RuntimeException('Audience (aud) de l\'id_token Google invalide.');
+        }
+        if (!isset($payload['email']) || !is_string($payload['email']) || trim($payload['email']) === '') {
+            throw new \RuntimeException('Email absent de l\'id_token Google.');
+        }
+        if (isset($payload['email_verified']) && $payload['email_verified'] === false) {
+            throw new \RuntimeException('Email Google non vérifié.');
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Récupère les JWKS Google (cache 1h du JSON brut, parse en mémoire à
+     * chaque verify : on ne peut pas cacher les objets Key parsés car ils
+     * contiennent des ressources OpenSSL non sérialisables).
+     *
+     * @return array<string, \Firebase\JWT\Key>
+     */
+    private function fetchJwks(): array
+    {
+        $rawJson = $this->cache->get(self::CACHE_KEY, function (ItemInterface $item): string {
+            $item->expiresAfter(self::CACHE_TTL);
+            try {
+                $response = $this->httpClient->request('GET', self::JWKS_URL, ['timeout' => 10]);
+                $body = $response->getContent(false);
+                $data = json_decode($body, true);
+                if (!is_array($data) || !isset($data['keys']) || !is_array($data['keys'])) {
+                    throw new \RuntimeException('JWKS Google sans champ "keys".');
+                }
+                return $body;
+            } catch (ExceptionInterface | \Throwable $e) {
+                $this->logger->error('Échec de récupération du JWKS Google.', ['exception' => $e->getMessage()]);
+                throw new \RuntimeException('Impossible de récupérer les clés publiques Google.', previous: $e);
+            }
+        });
+
+        $data = json_decode($rawJson, true);
+        if (!is_array($data)) {
+            throw new \RuntimeException('JWKS Google en cache illisible.');
+        }
+        return JWK::parseKeySet($data);
+    }
+}

--- a/backend/src/Service/GoogleAuthService.php
+++ b/backend/src/Service/GoogleAuthService.php
@@ -62,7 +62,10 @@ class GoogleAuthService
         if (!isset($payload['email']) || !is_string($payload['email']) || trim($payload['email']) === '') {
             throw new \RuntimeException('Email absent de l\'id_token Google.');
         }
-        if (isset($payload['email_verified']) && $payload['email_verified'] === false) {
+        // Fail-closed : un id_token sans `email_verified === true` est rejeté.
+        // Défense en profondeur contre un futur payload Google qui ometterait
+        // le claim ou un IDP malveillant qui le mettrait à false.
+        if (!isset($payload['email_verified']) || $payload['email_verified'] !== true) {
             throw new \RuntimeException('Email Google non vérifié.');
         }
 

--- a/backend/src/Service/GoogleCalendarService.php
+++ b/backend/src/Service/GoogleCalendarService.php
@@ -1,0 +1,317 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Integration;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Client Google Calendar v3 + gestion des tokens OAuth.
+ *
+ * Stratégie tokens :
+ *  - access_token (1h) stocké dans Integration::apiKey
+ *  - refresh_token (longue durée) stocké dans Integration::refreshToken
+ *  - expiration stockée dans Integration::tokenExpiresAt
+ *  - getValidAccessToken() refresh transparent quand l'access est expiré ou dans <60s.
+ *
+ * @see https://developers.google.com/identity/protocols/oauth2/web-server
+ * @see https://developers.google.com/calendar/api/v3/reference/events
+ */
+class GoogleCalendarService
+{
+    private const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+    private const CALENDAR_BASE = 'https://www.googleapis.com/calendar/v3';
+    private const REFRESH_SAFETY_MARGIN_SECONDS = 60;
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly EntityManagerInterface $em,
+        private readonly LoggerInterface $logger,
+        private readonly string $googleClientId,
+        private readonly string $googleClientSecret,
+    ) {}
+
+    /**
+     * Échange un authorization code contre access_token + refresh_token.
+     *
+     * @return array{access_token:string, refresh_token:?string, expires_in:int, scope:string}
+     * @throws \RuntimeException
+     */
+    public function exchangeCode(string $code, string $redirectUri): array
+    {
+        $this->assertCredentials();
+        try {
+            $response = $this->httpClient->request('POST', self::TOKEN_URL, [
+                'body' => [
+                    'code' => $code,
+                    'client_id' => $this->googleClientId,
+                    'client_secret' => $this->googleClientSecret,
+                    'redirect_uri' => $redirectUri,
+                    'grant_type' => 'authorization_code',
+                ],
+                'timeout' => 15,
+            ]);
+            if ($response->getStatusCode() !== 200) {
+                $body = $response->getContent(false);
+                $this->logger->warning('Échec d\'exchange code Google.', ['status' => $response->getStatusCode(), 'body' => $body]);
+                throw new \RuntimeException($this->extractGoogleMessage($body, 'Échec de l\'échange du code OAuth Google.'));
+            }
+            $data = $response->toArray(false);
+            if (!isset($data['access_token']) || !is_string($data['access_token'])) {
+                throw new \RuntimeException('Réponse Google sans access_token.');
+            }
+            return [
+                'access_token' => (string) $data['access_token'],
+                'refresh_token' => isset($data['refresh_token']) && is_string($data['refresh_token']) ? $data['refresh_token'] : null,
+                'expires_in' => isset($data['expires_in']) ? (int) $data['expires_in'] : 3600,
+                'scope' => isset($data['scope']) && is_string($data['scope']) ? $data['scope'] : '',
+            ];
+        } catch (ExceptionInterface | \Throwable $e) {
+            $this->logger->error('Exception lors de l\'exchange code Google.', ['exception' => $e->getMessage()]);
+            if ($e instanceof \RuntimeException) {
+                throw $e;
+            }
+            throw new \RuntimeException('Impossible de joindre Google : ' . $e->getMessage(), previous: $e);
+        }
+    }
+
+    /**
+     * Renouvelle l'access_token à partir du refresh_token stocké.
+     *
+     * @return array{access_token:string, expires_in:int}
+     * @throws \RuntimeException
+     */
+    public function refreshAccessToken(string $refreshToken): array
+    {
+        $this->assertCredentials();
+        try {
+            $response = $this->httpClient->request('POST', self::TOKEN_URL, [
+                'body' => [
+                    'client_id' => $this->googleClientId,
+                    'client_secret' => $this->googleClientSecret,
+                    'refresh_token' => $refreshToken,
+                    'grant_type' => 'refresh_token',
+                ],
+                'timeout' => 15,
+            ]);
+            if ($response->getStatusCode() !== 200) {
+                $body = $response->getContent(false);
+                $this->logger->warning('Échec de refresh token Google.', ['status' => $response->getStatusCode(), 'body' => $body]);
+                throw new \RuntimeException('Le refresh_token Google a été révoqué ou est invalide. Reconnectez Calendar.');
+            }
+            $data = $response->toArray(false);
+            if (!isset($data['access_token']) || !is_string($data['access_token'])) {
+                throw new \RuntimeException('Réponse Google sans access_token.');
+            }
+            return [
+                'access_token' => (string) $data['access_token'],
+                'expires_in' => isset($data['expires_in']) ? (int) $data['expires_in'] : 3600,
+            ];
+        } catch (ExceptionInterface | \Throwable $e) {
+            $this->logger->error('Exception lors du refresh token Google.', ['exception' => $e->getMessage()]);
+            if ($e instanceof \RuntimeException) {
+                throw $e;
+            }
+            throw new \RuntimeException('Impossible de joindre Google : ' . $e->getMessage(), previous: $e);
+        }
+    }
+
+    /**
+     * Retourne un access_token valide. Refresh transparent si expiré ou < 60s.
+     * Persiste les nouveaux tokens dans Integration.
+     *
+     * @throws \RuntimeException si pas de refresh_token disponible ou si le refresh échoue
+     */
+    public function getValidAccessToken(Integration $integration): string
+    {
+        $accessToken = $integration->getApiKey();
+        $expiresAt = $integration->getTokenExpiresAt();
+        $refreshToken = $integration->getRefreshToken();
+
+        $now = new \DateTimeImmutable();
+        $stillValid = $accessToken !== null && $accessToken !== ''
+            && $expiresAt !== null
+            && $expiresAt->getTimestamp() - $now->getTimestamp() > self::REFRESH_SAFETY_MARGIN_SECONDS;
+
+        if ($stillValid) {
+            return (string) $accessToken;
+        }
+
+        if ($refreshToken === null || $refreshToken === '') {
+            throw new \RuntimeException('Aucun refresh_token disponible. Reconnectez Calendar dans les paramètres.');
+        }
+
+        $refreshed = $this->refreshAccessToken($refreshToken);
+        $integration->setApiKey($refreshed['access_token']);
+        $integration->setTokenExpiresAt(
+            (new \DateTime())->modify('+' . (int) $refreshed['expires_in'] . ' seconds')
+        );
+        $this->em->flush();
+
+        return $refreshed['access_token'];
+    }
+
+    /**
+     * Crée un event Calendar et retourne son id.
+     *
+     * @throws \RuntimeException
+     */
+    public function createEvent(
+        Integration $integration,
+        string $summary,
+        ?string $description,
+        \DateTimeInterface $start,
+        \DateTimeInterface $end,
+    ): string {
+        $accessToken = $this->getValidAccessToken($integration);
+        try {
+            $response = $this->httpClient->request(
+                'POST',
+                self::CALENDAR_BASE . '/calendars/primary/events',
+                [
+                    'headers' => $this->headers($accessToken),
+                    'json' => $this->buildEventPayload($summary, $description, $start, $end),
+                    'timeout' => 15,
+                ],
+            );
+            if ($response->getStatusCode() < 200 || $response->getStatusCode() >= 300) {
+                $body = $response->getContent(false);
+                $this->logger->warning('Création d\'event Calendar en échec.', ['status' => $response->getStatusCode(), 'body' => $body]);
+                throw new \RuntimeException($this->extractGoogleMessage($body, 'Création de l\'event Google Calendar impossible.'));
+            }
+            $data = $response->toArray(false);
+            if (!isset($data['id']) || !is_string($data['id'])) {
+                throw new \RuntimeException('Réponse Google sans identifiant d\'event.');
+            }
+            return (string) $data['id'];
+        } catch (ExceptionInterface | \Throwable $e) {
+            $this->logger->error('Exception lors de la création d\'event Google.', ['exception' => $e->getMessage()]);
+            if ($e instanceof \RuntimeException) {
+                throw $e;
+            }
+            throw new \RuntimeException('Impossible de joindre Google Calendar : ' . $e->getMessage(), previous: $e);
+        }
+    }
+
+    /**
+     * Met à jour un event Calendar existant.
+     *
+     * @throws \RuntimeException
+     */
+    public function updateEvent(
+        Integration $integration,
+        string $eventId,
+        string $summary,
+        ?string $description,
+        \DateTimeInterface $start,
+        \DateTimeInterface $end,
+    ): void {
+        $accessToken = $this->getValidAccessToken($integration);
+        try {
+            $response = $this->httpClient->request(
+                'PATCH',
+                self::CALENDAR_BASE . '/calendars/primary/events/' . urlencode($eventId),
+                [
+                    'headers' => $this->headers($accessToken),
+                    'json' => $this->buildEventPayload($summary, $description, $start, $end),
+                    'timeout' => 15,
+                ],
+            );
+            if ($response->getStatusCode() < 200 || $response->getStatusCode() >= 300) {
+                $body = $response->getContent(false);
+                $this->logger->warning('Mise à jour d\'event Calendar en échec.', ['status' => $response->getStatusCode(), 'body' => $body]);
+                throw new \RuntimeException($this->extractGoogleMessage($body, 'Mise à jour de l\'event Google Calendar impossible.'));
+            }
+        } catch (ExceptionInterface | \Throwable $e) {
+            $this->logger->error('Exception lors de la mise à jour d\'event Google.', ['exception' => $e->getMessage()]);
+            if ($e instanceof \RuntimeException) {
+                throw $e;
+            }
+            throw new \RuntimeException('Impossible de joindre Google Calendar : ' . $e->getMessage(), previous: $e);
+        }
+    }
+
+    /**
+     * Supprime un event Calendar. Best-effort, log uniquement en cas d'échec.
+     */
+    public function deleteEvent(Integration $integration, string $eventId): void
+    {
+        try {
+            $accessToken = $this->getValidAccessToken($integration);
+            $this->httpClient->request(
+                'DELETE',
+                self::CALENDAR_BASE . '/calendars/primary/events/' . urlencode($eventId),
+                [
+                    'headers' => $this->headers($accessToken),
+                    'timeout' => 15,
+                ],
+            );
+        } catch (\Throwable $e) {
+            $this->logger->warning('Suppression d\'event Google Calendar en échec.', [
+                'eventId' => $eventId,
+                'exception' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildEventPayload(
+        string $summary,
+        ?string $description,
+        \DateTimeInterface $start,
+        \DateTimeInterface $end,
+    ): array {
+        return [
+            'summary' => mb_substr($summary, 0, 1024),
+            'description' => $description !== null ? mb_substr($description, 0, 8192) : null,
+            'start' => [
+                'dateTime' => $start->format(\DateTimeInterface::RFC3339),
+                'timeZone' => 'UTC',
+            ],
+            'end' => [
+                'dateTime' => $end->format(\DateTimeInterface::RFC3339),
+                'timeZone' => 'UTC',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function headers(string $accessToken): array
+    {
+        return [
+            'Authorization' => 'Bearer ' . $accessToken,
+            'Content-Type' => 'application/json',
+        ];
+    }
+
+    private function extractGoogleMessage(string $body, string $fallback): string
+    {
+        $data = json_decode($body, true);
+        if (is_array($data)) {
+            if (isset($data['error_description']) && is_string($data['error_description'])) {
+                return $data['error_description'];
+            }
+            if (isset($data['error']['message']) && is_string($data['error']['message'])) {
+                return $data['error']['message'];
+            }
+            if (isset($data['error']) && is_string($data['error'])) {
+                return $data['error'];
+            }
+        }
+        return $fallback;
+    }
+
+    private function assertCredentials(): void
+    {
+        if ($this->googleClientId === '' || $this->googleClientSecret === '') {
+            throw new \RuntimeException('GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET non configurés.');
+        }
+    }
+}

--- a/frontend/src/app/auth/google-calendar/callback/page.jsx
+++ b/frontend/src/app/auth/google-calendar/callback/page.jsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { useTranslation } from "@/hooks/useI18n";
+import { API_URL, Urls } from "@/utils/Api";
+
+/**
+ * Reçoit le redirect Google après autorisation Calendar.
+ * Échange le code reçu via le backend (qui appellera Google avec le client_secret),
+ * puis redirige vers Settings avec un toast de confirmation.
+ */
+const GoogleCalendarCallback = () => {
+    const router = useRouter();
+    const params = useSearchParams();
+    const { data: session, status: sessionStatus } = useSession();
+    const { t } = useTranslation();
+    const handledRef = useRef(false);
+
+    const token = session?.backendToken;
+
+    useEffect(() => {
+        if (sessionStatus === "loading") return;
+        if (sessionStatus !== "authenticated" || !token) {
+            // L'user n'est pas connecté — on le renvoie vers /auth en gardant le callback URL.
+            router.replace("/auth?callbackUrl=" + encodeURIComponent("/settings"));
+            return;
+        }
+        if (handledRef.current) return;
+        handledRef.current = true;
+
+        const code = params.get("code");
+        const errorParam = params.get("error");
+        if (errorParam) {
+            toast.error(t("settings.integrations.google.toast.consentDenied"));
+            router.replace("/settings");
+            return;
+        }
+        if (!code) {
+            toast.error(t("settings.integrations.google.toast.noCode"));
+            router.replace("/settings");
+            return;
+        }
+
+        const redirectUri = `${window.location.origin}/auth/google-calendar/callback`;
+
+        fetch(`${API_URL}${Urls.integrations.googleCalendarConnect}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+            body: JSON.stringify({ code, redirectUri }),
+        })
+            .then(async (res) => {
+                if (!res.ok) {
+                    let msg = t("settings.integrations.google.toast.connectError");
+                    try {
+                        const data = await res.json();
+                        if (data?.error) msg = data.error;
+                    } catch {
+                        /* fallback */
+                    }
+                    toast.error(msg);
+                    router.replace("/settings");
+                    return;
+                }
+                toast.success(t("settings.integrations.google.toast.connectSuccess"));
+                router.replace("/settings");
+            })
+            .catch(() => {
+                toast.error(t("settings.integrations.google.toast.connectError"));
+                router.replace("/settings");
+            });
+    }, [sessionStatus, token, params, router, t]);
+
+    return (
+        <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-950 text-slate-700 dark:text-slate-200">
+            <div className="flex items-center gap-3">
+                <Loader2 className="h-5 w-5 animate-spin" />
+                <p>{t("settings.integrations.google.callbackProcessing")}</p>
+            </div>
+        </div>
+    );
+};
+
+export default GoogleCalendarCallback;

--- a/frontend/src/app/auth/page.jsx
+++ b/frontend/src/app/auth/page.jsx
@@ -10,7 +10,7 @@ import { Label } from "@/components/Label";
 import { Button } from "@/components/Button";
 import { Input } from "@/components/Input";
 import { API_URL, Urls } from "@/utils/Api";
-import { LOGIN_INVALID, LOGIN_NETWORK } from "@/lib/auth";
+import { LOGIN_GOOGLE_REJECTED, LOGIN_INVALID, LOGIN_NETWORK } from "@/lib/auth";
 import { useTranslation } from "@/hooks/useI18n";
 
 const AuthPage = () => {
@@ -52,6 +52,26 @@ const AuthPage = () => {
             } else {
                 message = t("auth.toast.loginError");
             }
+            setError(message);
+            toast.error(message);
+            return;
+        }
+
+        toast.success(t("auth.toast.loginSuccess"));
+        router.push(res?.url || callbackUrl);
+        router.refresh();
+    };
+
+    const handleGoogleSignIn = async () => {
+        setError("");
+        setLoading(true);
+        const res = await signIn("google", { redirect: false, callbackUrl });
+        setLoading(false);
+
+        if (res?.error) {
+            const message = res.error === LOGIN_GOOGLE_REJECTED
+                ? t("auth.toast.googleRejected")
+                : t("auth.toast.googleError");
             setError(message);
             toast.error(message);
             return;
@@ -214,6 +234,34 @@ const AuthPage = () => {
                             </form>
                         </TabsContent>
                     </Tabs>
+
+                    <div className="mt-6">
+                        <div className="relative">
+                            <div className="absolute inset-0 flex items-center">
+                                <span className="w-full border-t border-slate-200 dark:border-slate-700" />
+                            </div>
+                            <div className="relative flex justify-center text-xs uppercase">
+                                <span className="bg-card px-2 text-slate-500 dark:text-slate-400">
+                                    {t("auth.providerSeparator")}
+                                </span>
+                            </div>
+                        </div>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            className="mt-4 w-full"
+                            onClick={handleGoogleSignIn}
+                            disabled={loading}
+                        >
+                            <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
+                                <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+                                <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+                                <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+                            </svg>
+                            {t("auth.googleButton")}
+                        </Button>
+                    </div>
                 </CardContent>
             </Card>
         </div>

--- a/frontend/src/app/settings/page.jsx
+++ b/frontend/src/app/settings/page.jsx
@@ -89,8 +89,11 @@ const Settings = () => {
     const [isSavingNotion, setIsSavingNotion] = useState(false);
     const [isDisconnectingNotion, setIsDisconnectingNotion] = useState(false);
 
-    // Google reste un placeholder désactivé (hors-scope MVP).
-    const [googleConnected] = useState(false);
+    // Intégration Google Calendar : fetchée depuis /api/integrations/google.
+    const [googleConnected, setGoogleConnected] = useState(false);
+    const [googleScopes, setGoogleScopes] = useState("");
+    const [googleLastSync, setGoogleLastSync] = useState(null);
+    const [isDisconnectingGoogle, setIsDisconnectingGoogle] = useState(false);
 
     useEffect(() => {
         if (sessionStatus !== "authenticated" || !token) return;
@@ -150,6 +153,70 @@ const Settings = () => {
             cancelled = true;
         };
     }, [sessionStatus, token]);
+
+    // Fetch de l'état Google (séparé pour pouvoir recharger après connect/disconnect).
+    useEffect(() => {
+        if (sessionStatus !== "authenticated" || !token) return;
+        let cancelled = false;
+        fetch(`${API_URL}${Urls.integrations.google}`, {
+            headers: { Authorization: `Bearer ${token}` },
+        })
+            .then(async (res) => {
+                if (cancelled || !res.ok) return;
+                const data = await res.json();
+                setGoogleConnected(Boolean(data?.connected));
+                setGoogleScopes(data?.scopes || "");
+                setGoogleLastSync(data?.lastSync || null);
+            })
+            .catch(() => {
+                /* silencieux */
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [sessionStatus, token]);
+
+    const handleConnectGoogleCalendar = () => {
+        const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+        if (!clientId) {
+            toast.error(t("settings.integrations.google.toast.clientIdMissing"));
+            return;
+        }
+        const redirectUri = `${window.location.origin}/auth/google-calendar/callback`;
+        const params = new URLSearchParams({
+            client_id: clientId,
+            redirect_uri: redirectUri,
+            response_type: "code",
+            scope: "https://www.googleapis.com/auth/calendar.events",
+            access_type: "offline",
+            prompt: "consent",
+            include_granted_scopes: "true",
+        });
+        window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+    };
+
+    const handleDisconnectGoogle = async () => {
+        if (!token) return;
+        setIsDisconnectingGoogle(true);
+        try {
+            const res = await fetch(`${API_URL}${Urls.integrations.google}`, {
+                method: "DELETE",
+                headers: { Authorization: `Bearer ${token}` },
+            });
+            if (!res.ok && res.status !== 204) {
+                toast.error(t("settings.integrations.google.toast.disconnectError"));
+                return;
+            }
+            setGoogleConnected(false);
+            setGoogleScopes("");
+            setGoogleLastSync(null);
+            toast.success(t("settings.integrations.google.toast.disconnectSuccess"));
+        } catch {
+            toast.error(t("settings.integrations.google.toast.disconnectError"));
+        } finally {
+            setIsDisconnectingGoogle(false);
+        }
+    };
 
     const handleConnectNotion = async () => {
         if (!token) return;
@@ -628,48 +695,79 @@ const Settings = () => {
 
                                 <Separator />
 
-                                <div className="flex items-center justify-between rounded-lg border dark:border-slate-800 p-4">
-                                    <div className="flex items-center gap-4">
-                                        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-slate-100 dark:bg-slate-800">
-                                            <svg className="h-6 w-6" viewBox="0 0 24 24">
-                                                <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
-                                                <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
-                                                <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
-                                                <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
-                                            </svg>
-                                        </div>
-                                        <div>
-                                            <div className="flex items-center gap-2">
-                                                <h3 className="font-medium">Google Account</h3>
-                                                {googleConnected ? (
-                                                    <Badge variant="default" className="gap-1">
-                                                        <Check className="h-3 w-3" />
-                                                        {t("common.connected")}
-                                                    </Badge>
-                                                ) : (
-                                                    <Badge variant="secondary" className="gap-1">
-                                                        <X className="h-3 w-3" />
-                                                        {t("common.disconnected")}
-                                                    </Badge>
-                                                )}
+                                <div className="rounded-lg border dark:border-slate-800 p-4">
+                                    <div className="flex items-center justify-between gap-4 flex-wrap">
+                                        <div className="flex items-center gap-4">
+                                            <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-slate-100 dark:bg-slate-800">
+                                                <svg className="h-6 w-6" viewBox="0 0 24 24">
+                                                    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
+                                                    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+                                                    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+                                                    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+                                                </svg>
                                             </div>
-                                            <p className="text-sm text-slate-600 dark:text-slate-400">
-                                                {t("settings.integrations.google.description")}
-                                            </p>
+                                            <div>
+                                                <div className="flex items-center gap-2">
+                                                    <h3 className="font-medium">Google Calendar</h3>
+                                                    {googleConnected ? (
+                                                        <Badge variant="default" className="gap-1">
+                                                            <Check className="h-3 w-3" />
+                                                            {t("common.connected")}
+                                                        </Badge>
+                                                    ) : (
+                                                        <Badge variant="secondary" className="gap-1">
+                                                            <X className="h-3 w-3" />
+                                                            {t("common.disconnected")}
+                                                        </Badge>
+                                                    )}
+                                                </div>
+                                                <p className="text-sm text-slate-600 dark:text-slate-400">
+                                                    {t("settings.integrations.google.description")}
+                                                </p>
+                                            </div>
                                         </div>
+                                        {googleConnected ? (
+                                            <Button
+                                                variant="outline"
+                                                onClick={handleDisconnectGoogle}
+                                                disabled={isDisconnectingGoogle}
+                                            >
+                                                {isDisconnectingGoogle && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                                {t("settings.integrations.google.disconnect")}
+                                            </Button>
+                                        ) : (
+                                            <Button variant="outline" onClick={handleConnectGoogleCalendar}>
+                                                {t("common.connect")}
+                                            </Button>
+                                        )}
                                     </div>
-                                    <Button
-                                        variant="outline"
-                                        disabled
-                                        title={t("settings.integrations.toast.googleSoon")}
-                                    >
-                                        {t("common.connect")}
-                                    </Button>
-                                </div>
 
-                                <p className="text-xs text-slate-500 dark:text-slate-400">
-                                    {t("settings.integrations.googleSoonHint")}
-                                </p>
+                                    {googleConnected && (
+                                        <div className="mt-4 grid gap-2 text-sm text-slate-600 dark:text-slate-400 sm:grid-cols-2">
+                                            <div className="space-y-1">
+                                                <p className="text-xs uppercase tracking-wide opacity-70">
+                                                    {t("settings.integrations.google.scopesLabel")}
+                                                </p>
+                                                <p className="text-xs font-mono break-all text-slate-700 dark:text-slate-300">
+                                                    {googleScopes || "—"}
+                                                </p>
+                                            </div>
+                                            <div className="space-y-1">
+                                                <p className="text-xs uppercase tracking-wide opacity-70">
+                                                    {t("settings.integrations.google.lastSyncLabel")}
+                                                </p>
+                                                <p className="text-slate-700 dark:text-slate-300">
+                                                    {googleLastSync
+                                                        ? new Date(googleLastSync).toLocaleString(locale === "en" ? "en-US" : "fr-FR", {
+                                                              dateStyle: "medium",
+                                                              timeStyle: "short",
+                                                          })
+                                                        : t("settings.integrations.google.neverSynced")}
+                                                </p>
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
                             </CardContent>
                         </Card>
                     </TabsContent>

--- a/frontend/src/components/editor/ArticleEditor.jsx
+++ b/frontend/src/components/editor/ArticleEditor.jsx
@@ -15,11 +15,14 @@ import {
     Share2,
     Loader2,
     RefreshCw,
+    CalendarClock,
+    BellRing,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Badge } from "@/components/Badge";
 import { Button } from "@/components/Button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/Card";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/Dialog";
 import { Input } from "@/components/Input";
 import { Label } from "@/components/Label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/Select";
@@ -67,6 +70,13 @@ export const ArticleEditor = ({ initialArticle = null, articleId = null }) => {
     const [isExportingPdf, setIsExportingPdf] = useState(false);
     const [isExportingNotion, setIsExportingNotion] = useState(false);
     const [notionPageId, setNotionPageId] = useState(initialArticle?.notionPageId ?? null);
+    const [scheduledAt, setScheduledAt] = useState(initialArticle?.scheduledAt ?? null);
+    const [scheduleInput, setScheduleInput] = useState("");
+    const [reminderInput, setReminderInput] = useState("");
+    const [isScheduling, setIsScheduling] = useState(false);
+    const [isReminding, setIsReminding] = useState(false);
+    const [scheduleDialogOpen, setScheduleDialogOpen] = useState(false);
+    const [reminderDialogOpen, setReminderDialogOpen] = useState(false);
 
     const token = session?.backendToken;
 
@@ -369,6 +379,94 @@ export const ArticleEditor = ({ initialArticle = null, articleId = null }) => {
             toast.error(t("editor.toast.notionError"));
         } finally {
             setIsExportingNotion(false);
+        }
+    };
+
+    const openScheduleDialog = () => {
+        if (!articleId) {
+            toast.info(t("editor.toast.notionSaveFirst"));
+            return;
+        }
+        // Pré-rempli avec la valeur courante, ou demain à 10h par défaut.
+        const defaultDate = scheduledAt
+            ? new Date(scheduledAt).toISOString().slice(0, 16)
+            : (() => {
+                const d = new Date();
+                d.setDate(d.getDate() + 1);
+                d.setHours(10, 0, 0, 0);
+                return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+            })();
+        setScheduleInput(defaultDate);
+        setScheduleDialogOpen(true);
+    };
+
+    const openReminderDialog = () => {
+        if (!articleId) {
+            toast.info(t("editor.toast.notionSaveFirst"));
+            return;
+        }
+        const d = new Date();
+        d.setDate(d.getDate() + 3);
+        d.setHours(9, 0, 0, 0);
+        setReminderInput(new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16));
+        setReminderDialogOpen(true);
+    };
+
+    const handleSchedule = async () => {
+        if (!token || !articleId) return;
+        if (!scheduleInput) {
+            toast.error(t("editor.toast.scheduleDateRequired"));
+            return;
+        }
+        setIsScheduling(true);
+        try {
+            const res = await fetch(`${API_URL}${Urls.articles.schedule(articleId)}`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+                body: JSON.stringify({ scheduledAt: new Date(scheduleInput).toISOString() }),
+            });
+            if (!res.ok) {
+                const message = await extractError(res, t("editor.toast.scheduleError"));
+                toast.error(message);
+                return;
+            }
+            const data = await res.json();
+            if (typeof data?.scheduledAt === "string") setScheduledAt(data.scheduledAt);
+            toast.success(t("editor.toast.scheduleSuccess"));
+            setScheduleDialogOpen(false);
+        } catch (err) {
+            console.error("article.schedule", err);
+            toast.error(t("editor.toast.scheduleError"));
+        } finally {
+            setIsScheduling(false);
+        }
+    };
+
+    const handleReminder = async () => {
+        if (!token || !articleId) return;
+        if (!reminderInput) {
+            toast.error(t("editor.toast.reminderDateRequired"));
+            return;
+        }
+        setIsReminding(true);
+        try {
+            const res = await fetch(`${API_URL}${Urls.articles.reminder(articleId)}`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+                body: JSON.stringify({ remindAt: new Date(reminderInput).toISOString() }),
+            });
+            if (!res.ok) {
+                const message = await extractError(res, t("editor.toast.reminderError"));
+                toast.error(message);
+                return;
+            }
+            toast.success(t("editor.toast.reminderSuccess"));
+            setReminderDialogOpen(false);
+        } catch (err) {
+            console.error("article.reminder", err);
+            toast.error(t("editor.toast.reminderError"));
+        } finally {
+            setIsReminding(false);
         }
     };
 
@@ -785,6 +883,24 @@ export const ArticleEditor = ({ initialArticle = null, articleId = null }) => {
                                             )}
                                             {t(notionPageId ? "editor.export.notionUpdate" : "editor.export.notion")}
                                         </Button>
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            className="w-full justify-start"
+                                            onClick={openScheduleDialog}
+                                        >
+                                            <CalendarClock className="mr-2 h-4 w-4" />
+                                            {t(scheduledAt ? "editor.export.scheduleUpdate" : "editor.export.schedule")}
+                                        </Button>
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            className="w-full justify-start"
+                                            onClick={openReminderDialog}
+                                        >
+                                            <BellRing className="mr-2 h-4 w-4" />
+                                            {t("editor.export.reminder")}
+                                        </Button>
                                     </CardContent>
                                 </Card>
                             </TabsContent>
@@ -792,6 +908,76 @@ export const ArticleEditor = ({ initialArticle = null, articleId = null }) => {
                     </div>
                 </div>
             </div>
+
+            <Dialog
+                open={scheduleDialogOpen}
+                onOpenChange={(open) => {
+                    if (!open && !isScheduling) setScheduleDialogOpen(false);
+                }}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>{t("editor.scheduleDialog.title")}</DialogTitle>
+                        <DialogDescription>{t("editor.scheduleDialog.description")}</DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-2 py-2">
+                        <Label htmlFor="schedule-input">{t("editor.scheduleDialog.label")}</Label>
+                        <Input
+                            id="schedule-input"
+                            type="datetime-local"
+                            value={scheduleInput}
+                            onChange={(e) => setScheduleInput(e.target.value)}
+                        />
+                        <p className="text-xs text-slate-500 dark:text-slate-400">
+                            {t("editor.scheduleDialog.hint")}
+                        </p>
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => setScheduleDialogOpen(false)} disabled={isScheduling}>
+                            {t("common.cancel")}
+                        </Button>
+                        <Button onClick={handleSchedule} disabled={isScheduling}>
+                            {isScheduling && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                            {t("editor.scheduleDialog.submit")}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog
+                open={reminderDialogOpen}
+                onOpenChange={(open) => {
+                    if (!open && !isReminding) setReminderDialogOpen(false);
+                }}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>{t("editor.reminderDialog.title")}</DialogTitle>
+                        <DialogDescription>{t("editor.reminderDialog.description")}</DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-2 py-2">
+                        <Label htmlFor="reminder-input">{t("editor.reminderDialog.label")}</Label>
+                        <Input
+                            id="reminder-input"
+                            type="datetime-local"
+                            value={reminderInput}
+                            onChange={(e) => setReminderInput(e.target.value)}
+                        />
+                        <p className="text-xs text-slate-500 dark:text-slate-400">
+                            {t("editor.reminderDialog.hint")}
+                        </p>
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => setReminderDialogOpen(false)} disabled={isReminding}>
+                            {t("common.cancel")}
+                        </Button>
+                        <Button onClick={handleReminder} disabled={isReminding}>
+                            {isReminding && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                            {t("editor.reminderDialog.submit")}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </div>
     );
 };

--- a/frontend/src/lib/auth.js
+++ b/frontend/src/lib/auth.js
@@ -1,8 +1,30 @@
 import CredentialsProvider from "next-auth/providers/credentials";
+import GoogleProvider from "next-auth/providers/google";
 import { API_URL, Urls } from "@/utils/Api";
 
 export const LOGIN_INVALID = "LOGIN_INVALID";
 export const LOGIN_NETWORK = "LOGIN_NETWORK";
+export const LOGIN_GOOGLE_REJECTED = "LOGIN_GOOGLE_REJECTED";
+
+/**
+ * Échange un id_token Google contre un JWT backend.
+ * Le backend vérifie la signature via JWKS Google et crée/retrouve le user.
+ */
+const exchangeGoogleIdToken = async (idToken) => {
+    const res = await fetch(`${API_URL}${Urls.auth.google}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ idToken }),
+    });
+    if (!res.ok) {
+        throw new Error(LOGIN_GOOGLE_REJECTED);
+    }
+    const data = await res.json().catch(() => null);
+    if (!data?.token || !data?.user) {
+        throw new Error(LOGIN_GOOGLE_REJECTED);
+    }
+    return data;
+};
 
 export const authOptions = {
     session: { strategy: "jwt" },
@@ -49,13 +71,49 @@ export const authOptions = {
                 };
             },
         }),
+        GoogleProvider({
+            clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+            // Scopes minimaux pour le Sign-In. Calendar demande son propre
+            // consentement séparé via /auth/google-calendar/callback.
+            authorization: { params: { scope: "openid email profile" } },
+        }),
     ],
     callbacks: {
-        async jwt({ token, user, trigger, session }) {
-            if (user) {
+        async signIn({ account, profile }) {
+            // Pour Google : on échange l'id_token contre un JWT backend avant
+            // de laisser NextAuth ouvrir la session. Si l'échange plante, on
+            // refuse l'auth (NextAuth redirige vers /auth?error=...).
+            if (account?.provider === "google") {
+                const idToken = account.id_token;
+                if (!idToken) {
+                    throw new Error(LOGIN_GOOGLE_REJECTED);
+                }
+                try {
+                    const data = await exchangeGoogleIdToken(idToken);
+                    // On stocke temporairement le backend payload sur le profile
+                    // pour que le callback jwt puisse le récupérer.
+                    profile._backend = data;
+                    return true;
+                } catch (err) {
+                    return false;
+                }
+            }
+            return true;
+        },
+        async jwt({ token, user, account, profile, trigger, session }) {
+            // CredentialsProvider : `user` contient déjà backendToken/user.
+            if (user?.backendToken) {
                 token.id = user.id;
                 token.backendToken = user.backendToken;
                 token.user = user.user;
+            }
+            // GoogleProvider : on attache le backend payload posé dans signIn().
+            if (account?.provider === "google" && profile?._backend) {
+                const data = profile._backend;
+                token.id = String(data.user.id);
+                token.backendToken = data.token;
+                token.user = data.user;
             }
             if (trigger === "update" && session?.user) {
                 token.user = { ...(token.user ?? {}), ...session.user };

--- a/frontend/src/lib/auth.js
+++ b/frontend/src/lib/auth.js
@@ -83,21 +83,17 @@ export const authOptions = {
         async signIn({ account, profile }) {
             // Pour Google : on échange l'id_token contre un JWT backend avant
             // de laisser NextAuth ouvrir la session. Si l'échange plante, on
-            // refuse l'auth (NextAuth redirige vers /auth?error=...).
+            // throw : NextAuth propage la cause vers `res.error` côté client.
             if (account?.provider === "google") {
                 const idToken = account.id_token;
                 if (!idToken) {
                     throw new Error(LOGIN_GOOGLE_REJECTED);
                 }
-                try {
-                    const data = await exchangeGoogleIdToken(idToken);
-                    // On stocke temporairement le backend payload sur le profile
-                    // pour que le callback jwt puisse le récupérer.
-                    profile._backend = data;
-                    return true;
-                } catch (err) {
-                    return false;
-                }
+                const data = await exchangeGoogleIdToken(idToken);
+                // On stocke temporairement le backend payload sur le profile
+                // pour que le callback jwt puisse le récupérer.
+                profile._backend = data;
+                return true;
             }
             return true;
         },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -76,6 +76,8 @@
       "fullNamePlaceholder": "John Doe",
       "submit": "Create account"
     },
+    "providerSeparator": "Or continue with",
+    "googleButton": "Continue with Google",
     "toast": {
       "loginSuccess": "Logged in. Welcome!",
       "loginInvalid": "Incorrect email or password.",
@@ -85,7 +87,9 @@
       "signupWelcome": "Welcome!",
       "signupCreatedButLoginFailed": "Account created, but automatic login failed. Please log in.",
       "signupError": "Sign-up error",
-      "logoutSuccess": "Logged out."
+      "logoutSuccess": "Logged out.",
+      "googleRejected": "Google sign-in rejected by the server.",
+      "googleError": "Google sign-in error."
     }
   },
   "home": {
@@ -455,7 +459,24 @@
       "pdf": "Export as PDF",
       "markdown": "Export as Markdown",
       "notion": "Send to Notion",
-      "notionUpdate": "Update on Notion"
+      "notionUpdate": "Update on Notion",
+      "schedule": "Schedule publication",
+      "scheduleUpdate": "Reschedule publication",
+      "reminder": "Set a reminder"
+    },
+    "scheduleDialog": {
+      "title": "Schedule publication",
+      "description": "Creates a Google Calendar event for this article. Reopening this dialog updates the event instead of duplicating it.",
+      "label": "Publication date and time",
+      "hint": "Event lasts 30 minutes by default. Calendar: primary.",
+      "submit": "Schedule"
+    },
+    "reminderDialog": {
+      "title": "Set a reminder",
+      "description": "Creates a Google Calendar event \"Reminder: review <title>\" at the chosen date.",
+      "label": "Reminder date and time",
+      "hint": "Event lasts 15 minutes by default. Calendar: primary.",
+      "submit": "Add reminder"
     },
     "toast": {
       "generated": "Content generated successfully!",
@@ -486,7 +507,13 @@
       "notionSaveFirst": "Save the article before sending it to Notion.",
       "notionCreated": "Article sent to Notion.",
       "notionUpdated": "Notion page updated.",
-      "notionError": "Sending to Notion failed."
+      "notionError": "Sending to Notion failed.",
+      "scheduleDateRequired": "Pick a publication date.",
+      "scheduleSuccess": "Publication scheduled in Google Calendar.",
+      "scheduleError": "Could not schedule publication.",
+      "reminderDateRequired": "Pick a date for the reminder.",
+      "reminderSuccess": "Reminder added to Google Calendar.",
+      "reminderError": "Could not add the reminder."
     }
   },
   "settings": {
@@ -531,11 +558,21 @@
         }
       },
       "google": {
-        "description": "Quick sign-in and access to Google services"
-      },
-      "googleSoonHint": "Google integration will be wired in a future release.",
-      "toast": {
-        "googleSoon": "Google integration is coming soon."
+        "description": "Connect Google Calendar to schedule publications and set reminders.",
+        "disconnect": "Disconnect",
+        "scopesLabel": "Granted permissions",
+        "lastSyncLabel": "Last synchronization",
+        "neverSynced": "Never synchronized",
+        "callbackProcessing": "Connecting to Google Calendar...",
+        "toast": {
+          "consentDenied": "You denied access to Google Calendar.",
+          "noCode": "Missing Google authorization code.",
+          "connectSuccess": "Google Calendar connected successfully.",
+          "connectError": "Could not connect to Google Calendar.",
+          "disconnectSuccess": "Google Calendar disconnected.",
+          "disconnectError": "Disconnect failed.",
+          "clientIdMissing": "NEXT_PUBLIC_GOOGLE_CLIENT_ID is not configured on the frontend."
+        }
       }
     },
     "notifications": {

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -76,6 +76,8 @@
       "fullNamePlaceholder": "Jean Dupont",
       "submit": "Créer un compte"
     },
+    "providerSeparator": "Ou continuer avec",
+    "googleButton": "Continuer avec Google",
     "toast": {
       "loginSuccess": "Connexion réussie. Bienvenue !",
       "loginInvalid": "Email ou mot de passe incorrect.",
@@ -85,7 +87,9 @@
       "signupWelcome": "Bienvenue !",
       "signupCreatedButLoginFailed": "Compte créé, mais connexion automatique impossible. Connectez-vous.",
       "signupError": "Erreur d'inscription",
-      "logoutSuccess": "Déconnexion réussie."
+      "logoutSuccess": "Déconnexion réussie.",
+      "googleRejected": "Connexion Google refusée par le serveur.",
+      "googleError": "Erreur lors de la connexion Google."
     }
   },
   "home": {
@@ -455,7 +459,24 @@
       "pdf": "Exporter en PDF",
       "markdown": "Exporter en Markdown",
       "notion": "Envoyer à Notion",
-      "notionUpdate": "Mettre à jour sur Notion"
+      "notionUpdate": "Mettre à jour sur Notion",
+      "schedule": "Planifier la publication",
+      "scheduleUpdate": "Modifier la date prévue",
+      "reminder": "Programmer un rappel"
+    },
+    "scheduleDialog": {
+      "title": "Planifier la publication",
+      "description": "Crée un event Google Calendar lié à cet article. Si tu reviens, la date sera modifiée au lieu de dupliquer.",
+      "label": "Date et heure de publication",
+      "hint": "L'event durera 30 minutes par défaut. Calendrier : principal.",
+      "submit": "Planifier"
+    },
+    "reminderDialog": {
+      "title": "Programmer un rappel",
+      "description": "Crée un event Google Calendar « Rappel : relire <titre> » à la date choisie.",
+      "label": "Date et heure du rappel",
+      "hint": "L'event durera 15 minutes par défaut. Calendrier : principal.",
+      "submit": "Programmer"
     },
     "toast": {
       "generated": "Contenu généré avec succès !",
@@ -486,7 +507,13 @@
       "notionSaveFirst": "Enregistrez d'abord l'article avant de l'envoyer à Notion.",
       "notionCreated": "Article envoyé vers Notion.",
       "notionUpdated": "Page Notion mise à jour.",
-      "notionError": "L'envoi vers Notion a échoué."
+      "notionError": "L'envoi vers Notion a échoué.",
+      "scheduleDateRequired": "Choisis une date de publication.",
+      "scheduleSuccess": "Publication planifiée dans Google Calendar.",
+      "scheduleError": "Impossible de planifier la publication.",
+      "reminderDateRequired": "Choisis une date pour le rappel.",
+      "reminderSuccess": "Rappel ajouté à Google Calendar.",
+      "reminderError": "Impossible de programmer le rappel."
     }
   },
   "settings": {
@@ -531,11 +558,21 @@
         }
       },
       "google": {
-        "description": "Connexion rapide et accès aux services Google"
-      },
-      "googleSoonHint": "L'intégration Google sera branchée dans une prochaine mise à jour.",
-      "toast": {
-        "googleSoon": "L'intégration Google arrive bientôt."
+        "description": "Connectez Google Calendar pour planifier vos publications et programmer des rappels.",
+        "disconnect": "Déconnecter",
+        "scopesLabel": "Permissions accordées",
+        "lastSyncLabel": "Dernière synchronisation",
+        "neverSynced": "Jamais synchronisé",
+        "callbackProcessing": "Connexion à Google Calendar en cours...",
+        "toast": {
+          "consentDenied": "Vous avez refusé l'accès à Google Calendar.",
+          "noCode": "Code d'autorisation Google manquant.",
+          "connectSuccess": "Google Calendar connecté avec succès.",
+          "connectError": "Impossible de connecter Google Calendar.",
+          "disconnectSuccess": "Google Calendar déconnecté.",
+          "disconnectError": "La déconnexion a échoué.",
+          "clientIdMissing": "NEXT_PUBLIC_GOOGLE_CLIENT_ID non configuré côté frontend."
+        }
       }
     },
     "notifications": {

--- a/frontend/src/utils/Api.js
+++ b/frontend/src/utils/Api.js
@@ -5,6 +5,7 @@ export const Urls = {
       login: '/auth/login',
       signup: '/auth/signup',
       logout: '/auth/logout',
+      google: '/auth/google',
   },
   user: {
       ips: '/user/ips',
@@ -21,9 +22,13 @@ export const Urls = {
       rewrite: '/articles/rewrite',
       aiAction: '/articles/ai-action',
       exportNotion: (id) => `/articles/${id}/export/notion`,
+      schedule: (id) => `/articles/${id}/schedule`,
+      reminder: (id) => `/articles/${id}/reminder`,
   },
   integrations: {
       notion: '/integrations/notion',
+      google: '/integrations/google',
+      googleCalendarConnect: '/integrations/google/calendar/connect',
   },
   me: {
       get: '/me',


### PR DESCRIPTION
## Contexte

Avant : seul `CredentialsProvider` (email/password) dans NextAuth. Carte Google dans Settings = toast « coming soon ». Cette PR livre **les deux** features en une fois :

1. **Sign-In Google** sur `/auth`.
2. **Google Calendar** : Settings → connect OAuth séparé. Éditeur : 2 boutons « Planifier la publication » + « Programmer un rappel ».

## Architecture OAuth

**Sign-In** : NextAuth `GoogleProvider` → callback `signIn` POST `id_token` au backend `/api/auth/google`. Backend vérifie signature via **JWKS Google** (cache 1h JSON brut, parse à chaque verify pour contourner le bug `OpenSSLAsymmetricKey serialization`), valide `aud == GOOGLE_CLIENT_ID`, `iss ∈ {accounts.google.com, https://accounts.google.com}`, `email_verified`. Crée/retrouve user par email. Shape `{ token, user }` conservé → reste de l'app inchangé.

**Calendar** : flow OAuth séparé (NextAuth ne demande pas refresh_token). Settings → bouton redirige vers `accounts.google.com/o/oauth2/v2/auth?scope=calendar.events&access_type=offline&prompt=consent`. Callback `/auth/google-calendar/callback` (page Next custom) POST le `code` au backend → échange contre `access_token` + `refresh_token` → stocke dans `Integration`. `getValidAccessToken` refresh transparent si expiré ou < 60s.

## Tests destructifs (20 vecteurs verts)

| # | Vecteur | Verdict |
|---|---|---|
| 1-4 | id_token forgé/corrompu/manquant + JSON malformé → 400/401 | ✅ |
| 5-9 | Endpoints integration sans/avec body invalide → 400/401/502 propres | ✅ |
| 10-12 | Schedule sans body / date passée / invalide → 400 FR | ✅ |
| 13 | **IDOR schedule** : article B avec JWT A → 404 | ✅ |
| 14 | Schedule sans integration → 400 FR « Connectez Google Calendar » | ✅ |
| 15-16 | **IDOR reminder** + date passée → 404/400 FR | ✅ |
| 17 | Refresh : token expiré + refresh bidon → 502 FR « Reconnectez Calendar » | ✅ |
| 18 | Refresh : pas de refresh_token → 502 FR « Aucun refresh_token disponible » | ✅ |
| 19 | **Anti-leak** : canary `LEAK_CANARY` planté dans `api_key`/`refresh_token` jamais retourné par aucun endpoint | ✅ |
| 20 | DELETE integration A : nettoie `google_event_id` des articles de A SEULEMENT (B intact) | ✅ |

`doctrine:schema:validate` : in sync. `eslint` : 0 erreur. Parité fr↔en : 0 clé divergente.

## Cas non testé automatiquement (à valider par le reviewer)

Le **happy path OAuth réel** nécessite une session navigateur.

1. `php bin/console doctrine:migrations:migrate --no-interaction`.
2. Credentials Google Cloud avec redirect URIs :
   - `http://localhost:3000/api/auth/callback/google`
   - `http://localhost:3000/auth/google-calendar/callback`
3. Renseigner dans `frontend/.env.local` + `backend/.env.local` (gitignored).
4. Smoke :
   - [ ] `/auth` → « Continuer avec Google » → consent → /dashboard, user créé/retrouvé.
   - [ ] Settings → tab Intégrations → carte Google « Connecter » → consent calendar → toast success, badge « Connecté ».
   - [ ] Éditeur → article saved → « Planifier la publication » → date → toast → event visible dans Google Calendar.
   - [ ] Re-cliquer avec autre date → event mis à jour au même endroit (pas dupliqué).
   - [ ] « Programmer un rappel » → event « Rappel : relire <titre> » dans Calendar.
   - [ ] Settings → Disconnect → badge « Déconnecté », articles perdent `googleEventId`.

## Choix MVP assumés

- **Tokens stockés en clair** dans `integration` (cohérent avec `Notion::apiKey`). Pas de chiffrement au repos pour cette PR.
- **Race condition** double-schedule concurrent : 2 events possibles. Acceptable MVP.
- Si l'utilisateur révoque le token Google côté Google : détecté au prochain appel → 502 explicite « Reconnectez Calendar ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)