### PR TITLE
refactor(ui): refonte design et UX des pages user

### DIFF
--- a/frontend/src/app/auth/page.jsx
+++ b/frontend/src/app/auth/page.jsx
@@ -138,26 +138,50 @@ const AuthPage = () => {
     };
 
     return (
-        <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-emerald-900 p-4">
-            <Card className="w-full max-w-md">
-                <CardHeader className="space-y-1 text-center">
-                    <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500">
-                        <PenTool className="h-6 w-6 text-white" />
+        <div className="relative flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-950 p-4 overflow-hidden">
+            {/* Décor : halos doux pour habiller le fond sans gradients criards */}
+            <div
+                aria-hidden
+                className="pointer-events-none absolute -top-32 -left-32 h-96 w-96 rounded-full bg-emerald-200/40 blur-3xl dark:bg-emerald-900/20"
+            />
+            <div
+                aria-hidden
+                className="pointer-events-none absolute -bottom-32 -right-32 h-96 w-96 rounded-full bg-emerald-100/60 blur-3xl dark:bg-emerald-950/30"
+            />
+
+            <Card className="relative w-full max-w-md rounded-2xl border-slate-200 bg-white/95 shadow-xl backdrop-blur-sm dark:border-slate-800 dark:bg-slate-900/95">
+                <CardHeader className="space-y-2 text-center">
+                    <div className="mx-auto mb-2 grid h-12 w-12 place-items-center rounded-2xl bg-emerald-500/15 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-400">
+                        <PenTool className="h-5 w-5" />
                     </div>
-                    <CardTitle className="text-2xl">{t("brand")}</CardTitle>
-                    <CardDescription>{t("auth.tagline")}</CardDescription>
+                    <CardTitle className="text-2xl font-semibold tracking-tight">{t("brand")}</CardTitle>
+                    <CardDescription className="text-slate-600 dark:text-slate-400">{t("auth.tagline")}</CardDescription>
                 </CardHeader>
                 <CardContent>
                     <Tabs defaultValue="login" className="w-full">
-                        <TabsList className="grid w-full grid-cols-2">
-                            <TabsTrigger value="login">{t("auth.tabs.login")}</TabsTrigger>
-                            <TabsTrigger value="signup">{t("auth.tabs.signup")}</TabsTrigger>
+                        <TabsList className="grid w-full grid-cols-2 bg-slate-100 dark:bg-slate-800 rounded-xl p-1 h-auto">
+                            <TabsTrigger
+                                value="login"
+                                className="rounded-lg data-[state=active]:bg-white data-[state=active]:text-slate-900 data-[state=active]:shadow-sm dark:data-[state=active]:bg-slate-900 dark:data-[state=active]:text-slate-100"
+                            >
+                                {t("auth.tabs.login")}
+                            </TabsTrigger>
+                            <TabsTrigger
+                                value="signup"
+                                className="rounded-lg data-[state=active]:bg-white data-[state=active]:text-slate-900 data-[state=active]:shadow-sm dark:data-[state=active]:bg-slate-900 dark:data-[state=active]:text-slate-100"
+                            >
+                                {t("auth.tabs.signup")}
+                            </TabsTrigger>
                         </TabsList>
 
-                        <TabsContent value="login" className="space-y-4">
-                            {error && <div className="rounded-md bg-red-50 dark:bg-red-950/30 p-3 text-sm text-red-600 dark:text-red-400">{error}</div>}
+                        <TabsContent value="login" className="space-y-4 mt-5">
+                            {error && (
+                                <div className="rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-400">
+                                    {error}
+                                </div>
+                            )}
                             <form onSubmit={handleLogin} className="space-y-4">
-                                <div className="space-y-2">
+                                <div className="space-y-1.5">
                                     <Label htmlFor="email">{t("form.email")}</Label>
                                     <Input
                                         id="email"
@@ -169,7 +193,7 @@ const AuthPage = () => {
                                         disabled={loading}
                                     />
                                 </div>
-                                <div className="space-y-2">
+                                <div className="space-y-1.5">
                                     <Label htmlFor="password">{t("form.password")}</Label>
                                     <Input
                                         id="password"
@@ -181,17 +205,25 @@ const AuthPage = () => {
                                         disabled={loading}
                                     />
                                 </div>
-                                <Button type="submit" className="w-full" disabled={loading}>
-                                    {loading ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : ""}
+                                <Button
+                                    type="submit"
+                                    className="w-full rounded-lg bg-emerald-600 text-white hover:bg-emerald-700"
+                                    disabled={loading}
+                                >
+                                    {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                                     {t("auth.login.submit")}
                                 </Button>
                             </form>
                         </TabsContent>
 
-                        <TabsContent value="signup" className="space-y-4">
-                            {error && <div className="rounded-md bg-red-50 dark:bg-red-950/30 p-3 text-sm text-red-600 dark:text-red-400">{error}</div>}
+                        <TabsContent value="signup" className="space-y-4 mt-5">
+                            {error && (
+                                <div className="rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-400">
+                                    {error}
+                                </div>
+                            )}
                             <form onSubmit={handleSignup} className="space-y-4">
-                                <div className="space-y-2">
+                                <div className="space-y-1.5">
                                     <Label htmlFor="signup-name">{t("auth.signup.fullName")}</Label>
                                     <Input
                                         id="signup-name"
@@ -203,7 +235,7 @@ const AuthPage = () => {
                                         disabled={loading}
                                     />
                                 </div>
-                                <div className="space-y-2">
+                                <div className="space-y-1.5">
                                     <Label htmlFor="signup-email">{t("form.email")}</Label>
                                     <Input
                                         id="signup-email"
@@ -215,7 +247,7 @@ const AuthPage = () => {
                                         disabled={loading}
                                     />
                                 </div>
-                                <div className="space-y-2">
+                                <div className="space-y-1.5">
                                     <Label htmlFor="signup-password">{t("form.password")}</Label>
                                     <Input
                                         id="signup-password"
@@ -227,8 +259,12 @@ const AuthPage = () => {
                                         disabled={loading}
                                     />
                                 </div>
-                                <Button type="submit" className="w-full" disabled={loading}>
-                                    {loading ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : ""}
+                                <Button
+                                    type="submit"
+                                    className="w-full rounded-lg bg-emerald-600 text-white hover:bg-emerald-700"
+                                    disabled={loading}
+                                >
+                                    {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                                     {t("auth.signup.submit")}
                                 </Button>
                             </form>
@@ -238,10 +274,10 @@ const AuthPage = () => {
                     <div className="mt-6">
                         <div className="relative">
                             <div className="absolute inset-0 flex items-center">
-                                <span className="w-full border-t border-slate-200 dark:border-slate-700" />
+                                <span className="w-full border-t border-slate-200 dark:border-slate-800" />
                             </div>
-                            <div className="relative flex justify-center text-xs uppercase">
-                                <span className="bg-card px-2 text-slate-500 dark:text-slate-400">
+                            <div className="relative flex justify-center text-xs">
+                                <span className="bg-white px-3 text-slate-500 dark:bg-slate-900 dark:text-slate-400">
                                     {t("auth.providerSeparator")}
                                 </span>
                             </div>
@@ -249,7 +285,7 @@ const AuthPage = () => {
                         <Button
                             type="button"
                             variant="outline"
-                            className="mt-4 w-full"
+                            className="mt-4 w-full rounded-lg border-slate-200 dark:border-slate-800"
                             onClick={handleGoogleSignIn}
                             disabled={loading}
                         >

--- a/frontend/src/app/dashboard/page.jsx
+++ b/frontend/src/app/dashboard/page.jsx
@@ -4,20 +4,15 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from "@/components/Card";
-import { Button } from "@/components/Button";
-import {
     FileText,
     TrendingUp,
     Calendar,
     Sparkles,
     ArrowRight,
     Loader2,
+    PenSquare,
+    Lightbulb,
+    History,
 } from "lucide-react";
 import {
     LineChart,
@@ -31,14 +26,16 @@ import {
     ResponsiveContainer,
 } from "recharts";
 import { toast } from "sonner";
+import { Button } from "@/components/Button";
+import { PageShell, PageHeader, StatCard, SectionCard, EmptyState, StatusBadge } from "@/components/ui-kit";
 import { useTranslation } from "@/hooks/useI18n";
 import { API_URL, Urls } from "@/utils/Api";
 
-const STATUS_COLOR = {
-    published: "text-emerald-600 dark:text-emerald-400",
-    draft: "text-slate-500 dark:text-slate-400",
-    review: "text-amber-600 dark:text-amber-400",
-    archived: "text-slate-400 dark:text-slate-500",
+const STATUS_VARIANT = {
+    published: "published",
+    draft: "draft",
+    review: "review",
+    archived: "archived",
 };
 
 const shortDate = (iso, locale) => {
@@ -78,6 +75,11 @@ const formatCompactNumber = (value, locale) => {
     }
 };
 
+const firstName = (fullName) => {
+    if (!fullName || typeof fullName !== "string") return "";
+    return fullName.trim().split(/\s+/)[0] || "";
+};
+
 const Dashboard = () => {
     const { t, locale } = useTranslation();
     const { data: session, status: sessionStatus } = useSession();
@@ -87,6 +89,7 @@ const Dashboard = () => {
     const tRef = useRef(t);
     tRef.current = t;
     const token = session?.backendToken;
+    const userFirstName = firstName(session?.user?.name);
 
     useEffect(() => {
         if (sessionStatus !== "authenticated" || !token) return;
@@ -140,35 +143,36 @@ const Dashboard = () => {
     }));
     const recentArticles = stats.recentArticles || [];
 
+    const greetingTitle = userFirstName
+        ? t("dashboard.greeting", { name: userFirstName })
+        : t("dashboard.greetingGeneric");
+
     const kpis = [
         {
             key: "articles",
             icon: FileText,
-            iconBg: "bg-emerald-100 dark:bg-emerald-950/40",
-            iconColor: "text-emerald-600 dark:text-emerald-400",
+            tone: "emerald",
             value: totals.articles ?? 0,
         },
         {
             key: "words",
             icon: Sparkles,
-            iconBg: "bg-blue-100 dark:bg-blue-950/40",
-            iconColor: "text-blue-600 dark:text-blue-400",
+            tone: "blue",
             value: formatCompactNumber(totals.wordsTotal ?? 0, locale),
         },
         {
             key: "seoScore",
             icon: TrendingUp,
-            iconBg: "bg-amber-100 dark:bg-amber-950/40",
-            iconColor: "text-amber-600 dark:text-amber-400",
-            value: totals.seoAverage === null || totals.seoAverage === undefined
-                ? t("dashboard.stats.noSeo")
-                : `${totals.seoAverage}%`,
+            tone: "amber",
+            value:
+                totals.seoAverage === null || totals.seoAverage === undefined
+                    ? t("dashboard.stats.noSeo")
+                    : `${totals.seoAverage}%`,
         },
         {
             key: "lastActivity",
             icon: Calendar,
-            iconBg: "bg-slate-100 dark:bg-slate-800",
-            iconColor: "text-slate-600 dark:text-slate-300",
+            tone: "slate",
             value: totals.lastActivity
                 ? longDate(totals.lastActivity, locale)
                 : t("dashboard.stats.noActivity"),
@@ -176,176 +180,182 @@ const Dashboard = () => {
     ];
 
     return (
-        <div className="flex-1 overflow-auto bg-slate-50 dark:bg-slate-950 p-4 md:p-8">
-            <div className="mx-auto max-w-7xl space-y-6 md:space-y-8">
-                <div>
-                    <h1 className="text-2xl md:text-3xl">{t("dashboard.title")}</h1>
-                    <p className="text-slate-600 dark:text-slate-400">{t("dashboard.subtitle")}</p>
-                </div>
+        <PageShell>
+            <PageHeader
+                eyebrow={t("dashboard.eyebrow")}
+                title={greetingTitle}
+                description={t("dashboard.subtitle")}
+                actions={
+                    <>
+                        <Button asChild variant="outline" className="rounded-lg">
+                            <Link href="/ideas">
+                                <Lightbulb className="mr-2 h-4 w-4" />
+                                {t("dashboard.quickActions.ideas")}
+                            </Link>
+                        </Button>
+                        <Button asChild className="rounded-lg bg-emerald-600 text-white hover:bg-emerald-700">
+                            <Link href="/editor">
+                                <PenSquare className="mr-2 h-4 w-4" />
+                                {t("dashboard.quickActions.newArticle")}
+                            </Link>
+                        </Button>
+                    </>
+                }
+            />
 
-                <div className="grid gap-4 md:gap-6 grid-cols-2 lg:grid-cols-4">
-                    {kpis.map((kpi) => {
-                        const Icon = kpi.icon;
-                        return (
-                            <div
-                                key={kpi.key}
-                                className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900"
-                            >
-                                <div className="flex items-center justify-between">
-                                    <span className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                                        {t(`dashboard.stats.${kpi.key}`)}
-                                    </span>
-                                    <span className={`grid h-9 w-9 place-items-center rounded-xl ${kpi.iconBg}`}>
-                                        <Icon className={`h-4 w-4 ${kpi.iconColor}`} />
-                                    </span>
-                                </div>
-                                <p className="mt-3 text-2xl md:text-3xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
-                                    {kpi.value}
-                                </p>
-                            </div>
-                        );
-                    })}
-                </div>
+            <div className="grid gap-4 md:gap-6 grid-cols-2 lg:grid-cols-4">
+                {kpis.map((kpi) => (
+                    <StatCard
+                        key={kpi.key}
+                        label={t(`dashboard.stats.${kpi.key}`)}
+                        value={kpi.value}
+                        icon={kpi.icon}
+                        tone={kpi.tone}
+                    />
+                ))}
+            </div>
 
-                <div className="grid gap-6 lg:grid-cols-2">
-                    <Card>
-                        <CardHeader>
-                            <CardTitle>{t("dashboard.weekActivity.title")}</CardTitle>
-                            <CardDescription>
-                                {t("dashboard.weekActivity.description", { days: stats.windowDays })}
-                            </CardDescription>
-                        </CardHeader>
-                        <CardContent>
-                            <ResponsiveContainer width="100%" height={280}>
-                                <AreaChart data={series} margin={{ left: -20, right: 8, top: 8, bottom: 0 }}>
-                                    <defs>
-                                        <linearGradient id="dashboardArticlesGrad" x1="0" y1="0" x2="0" y2="1">
-                                            <stop offset="0%" stopColor="#10b981" stopOpacity={0.35} />
-                                            <stop offset="100%" stopColor="#10b981" stopOpacity={0} />
-                                        </linearGradient>
-                                    </defs>
-                                    <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" className="dark:stroke-slate-800" />
-                                    <XAxis dataKey="label" stroke="#94a3b8" fontSize={11} tickLine={false} axisLine={false} />
-                                    <YAxis allowDecimals={false} stroke="#94a3b8" fontSize={11} tickLine={false} axisLine={false} />
-                                    <Tooltip contentStyle={{ borderRadius: 12, fontSize: 12, border: "1px solid #e2e8f0" }} />
-                                    <Area
-                                        type="monotone"
-                                        dataKey="articles"
-                                        stroke="#10b981"
-                                        strokeWidth={2.5}
-                                        fill="url(#dashboardArticlesGrad)"
-                                        name={t("dashboard.weekActivity.legend")}
-                                    />
-                                </AreaChart>
-                            </ResponsiveContainer>
-                        </CardContent>
-                    </Card>
+            <div className="grid gap-4 md:gap-6 lg:grid-cols-2">
+                <SectionCard
+                    title={t("dashboard.weekActivity.title")}
+                    description={t("dashboard.weekActivity.description", { days: stats.windowDays })}
+                    padding="md"
+                >
+                    <ResponsiveContainer width="100%" height={260}>
+                        <AreaChart data={series} margin={{ left: -16, right: 8, top: 4, bottom: 0 }}>
+                            <defs>
+                                <linearGradient id="dashboardArticlesGrad" x1="0" y1="0" x2="0" y2="1">
+                                    <stop offset="0%" stopColor="#10b981" stopOpacity={0.32} />
+                                    <stop offset="100%" stopColor="#10b981" stopOpacity={0} />
+                                </linearGradient>
+                            </defs>
+                            <CartesianGrid strokeDasharray="3 3" stroke="currentColor" className="text-slate-200 dark:text-slate-800" />
+                            <XAxis dataKey="label" stroke="currentColor" className="text-slate-400 dark:text-slate-500" fontSize={11} tickLine={false} axisLine={false} />
+                            <YAxis allowDecimals={false} stroke="currentColor" className="text-slate-400 dark:text-slate-500" fontSize={11} tickLine={false} axisLine={false} />
+                            <Tooltip
+                                cursor={{ stroke: "#10b981", strokeOpacity: 0.2 }}
+                                contentStyle={{
+                                    borderRadius: 12,
+                                    fontSize: 12,
+                                    border: "1px solid rgb(226 232 240)",
+                                    background: "white",
+                                    boxShadow: "0 4px 12px -2px rgb(0 0 0 / 0.08)",
+                                }}
+                            />
+                            <Area
+                                type="monotone"
+                                dataKey="articles"
+                                stroke="#10b981"
+                                strokeWidth={2.5}
+                                fill="url(#dashboardArticlesGrad)"
+                                name={t("dashboard.weekActivity.legend")}
+                            />
+                        </AreaChart>
+                    </ResponsiveContainer>
+                </SectionCard>
 
-                    <Card>
-                        <CardHeader>
-                            <CardTitle>{t("dashboard.wordsChart.title")}</CardTitle>
-                            <CardDescription>
-                                {t("dashboard.wordsChart.description", { days: stats.windowDays })}
-                            </CardDescription>
-                        </CardHeader>
-                        <CardContent>
-                            <ResponsiveContainer width="100%" height={280}>
-                                <LineChart data={series} margin={{ left: -20, right: 8, top: 8, bottom: 0 }}>
-                                    <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" className="dark:stroke-slate-800" />
-                                    <XAxis dataKey="label" stroke="#94a3b8" fontSize={11} tickLine={false} axisLine={false} />
-                                    <YAxis allowDecimals={false} stroke="#94a3b8" fontSize={11} tickLine={false} axisLine={false} />
-                                    <Tooltip contentStyle={{ borderRadius: 12, fontSize: 12, border: "1px solid #e2e8f0" }} />
-                                    <Line
-                                        type="monotone"
-                                        dataKey="words"
-                                        stroke="#3b82f6"
-                                        strokeWidth={2.5}
-                                        dot={false}
-                                        name={t("dashboard.wordsChart.legend")}
-                                    />
-                                </LineChart>
-                            </ResponsiveContainer>
-                        </CardContent>
-                    </Card>
-                </div>
+                <SectionCard
+                    title={t("dashboard.wordsChart.title")}
+                    description={t("dashboard.wordsChart.description", { days: stats.windowDays })}
+                    padding="md"
+                >
+                    <ResponsiveContainer width="100%" height={260}>
+                        <LineChart data={series} margin={{ left: -16, right: 8, top: 4, bottom: 0 }}>
+                            <CartesianGrid strokeDasharray="3 3" stroke="currentColor" className="text-slate-200 dark:text-slate-800" />
+                            <XAxis dataKey="label" stroke="currentColor" className="text-slate-400 dark:text-slate-500" fontSize={11} tickLine={false} axisLine={false} />
+                            <YAxis allowDecimals={false} stroke="currentColor" className="text-slate-400 dark:text-slate-500" fontSize={11} tickLine={false} axisLine={false} />
+                            <Tooltip
+                                cursor={{ stroke: "#64748b", strokeOpacity: 0.2 }}
+                                contentStyle={{
+                                    borderRadius: 12,
+                                    fontSize: 12,
+                                    border: "1px solid rgb(226 232 240)",
+                                    background: "white",
+                                    boxShadow: "0 4px 12px -2px rgb(0 0 0 / 0.08)",
+                                }}
+                            />
+                            <Line
+                                type="monotone"
+                                dataKey="words"
+                                stroke="#475569"
+                                strokeWidth={2.5}
+                                dot={false}
+                                name={t("dashboard.wordsChart.legend")}
+                            />
+                        </LineChart>
+                    </ResponsiveContainer>
+                </SectionCard>
+            </div>
 
-                <div className="grid gap-6 lg:grid-cols-3">
-                    <Card className="lg:col-span-2">
-                        <CardHeader>
-                            <CardTitle>{t("dashboard.recent.title")}</CardTitle>
-                            <CardDescription>{t("dashboard.recent.description")}</CardDescription>
-                        </CardHeader>
-                        <CardContent>
-                            {recentArticles.length === 0 ? (
-                                <div className="rounded-xl border border-dashed border-slate-200 dark:border-slate-700 py-10 text-center text-sm text-slate-500 dark:text-slate-400">
-                                    {t("dashboard.recent.empty")}
-                                </div>
-                            ) : (
-                                <div className="space-y-3">
-                                    {recentArticles.map((article) => {
-                                        const statusLabel = t(`dashboard.recent.status.${article.status}`);
-                                        return (
-                                            <Link
-                                                key={article.id}
-                                                href={`/editor/${article.id}`}
-                                                className="flex items-center justify-between gap-3 rounded-xl border border-slate-200 bg-white p-3 transition hover:border-slate-300 hover:shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-700"
-                                            >
-                                                <div className="min-w-0 space-y-1">
-                                                    <p className="truncate font-medium text-slate-900 dark:text-slate-100">{article.title}</p>
-                                                    <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
-                                                        <span>{longDate(article.updatedAt, locale)}</span>
-                                                        <span aria-hidden>•</span>
-                                                        <span className={STATUS_COLOR[article.status] || "text-slate-500 dark:text-slate-400"}>{statusLabel}</span>
-                                                    </div>
-                                                </div>
-                                                <div className="flex shrink-0 items-center gap-3">
-                                                    <div className="text-right">
-                                                        <p className="text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                                                            {t("dashboard.recent.seoScoreLabel")}
-                                                        </p>
-                                                        <p className="text-base font-semibold text-emerald-600 dark:text-emerald-400">
-                                                            {article.seoScore === null || article.seoScore === undefined ? "—" : `${article.seoScore}%`}
-                                                        </p>
-                                                    </div>
-                                                    <ArrowRight className="h-4 w-4 text-slate-400 dark:text-slate-500" />
-                                                </div>
-                                            </Link>
-                                        );
-                                    })}
-                                </div>
-                            )}
-                        </CardContent>
-                    </Card>
-
-                    <Card>
-                        <CardHeader>
-                            <CardTitle>{t("dashboard.quickActions.title")}</CardTitle>
-                            <CardDescription>{t("dashboard.quickActions.description")}</CardDescription>
-                        </CardHeader>
-                        <CardContent className="space-y-3">
-                            <Button asChild className="w-full justify-start" variant="outline">
-                                <Link href="/ideas">
-                                    <Sparkles className="mr-2 h-4 w-4" />
-                                    {t("dashboard.quickActions.ideas")}
-                                </Link>
-                            </Button>
-                            <Button asChild className="w-full justify-start">
+            <SectionCard
+                title={t("dashboard.recent.title")}
+                description={t("dashboard.recent.description")}
+                actions={
+                    <Button asChild variant="ghost" size="sm" className="rounded-lg text-emerald-600 hover:bg-emerald-50 hover:text-emerald-700 dark:text-emerald-400 dark:hover:bg-emerald-950/40">
+                        <Link href="/history">
+                            <History className="mr-2 h-4 w-4" />
+                            {t("dashboard.quickActions.history")}
+                        </Link>
+                    </Button>
+                }
+                padding="md"
+            >
+                {recentArticles.length === 0 ? (
+                    <EmptyState
+                        icon={FileText}
+                        title={t("dashboard.recent.emptyTitle")}
+                        description={t("dashboard.recent.empty")}
+                        action={
+                            <Button asChild className="rounded-lg bg-emerald-600 text-white hover:bg-emerald-700">
                                 <Link href="/editor">
-                                    <FileText className="mr-2 h-4 w-4" />
+                                    <PenSquare className="mr-2 h-4 w-4" />
                                     {t("dashboard.quickActions.newArticle")}
                                 </Link>
                             </Button>
-                            <Button asChild className="w-full justify-start" variant="outline">
-                                <Link href="/history">
-                                    <Calendar className="mr-2 h-4 w-4" />
-                                    {t("dashboard.quickActions.history")}
-                                </Link>
-                            </Button>
-                        </CardContent>
-                    </Card>
-                </div>
-            </div>
-        </div>
+                        }
+                    />
+                ) : (
+                    <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+                        {recentArticles.map((article) => {
+                            const statusLabel = t(`dashboard.recent.status.${article.status}`);
+                            const variant = STATUS_VARIANT[article.status] || "draft";
+                            return (
+                                <li key={article.id}>
+                                    <Link
+                                        href={`/editor/${article.id}`}
+                                        className="group flex items-center justify-between gap-4 rounded-xl px-3 py-3.5 -mx-3 transition hover:bg-slate-50 dark:hover:bg-slate-800/40"
+                                    >
+                                        <div className="min-w-0 flex-1">
+                                            <p className="truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
+                                                {article.title}
+                                            </p>
+                                            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                                                <StatusBadge variant={variant}>{statusLabel}</StatusBadge>
+                                                <span aria-hidden>•</span>
+                                                <span>{longDate(article.updatedAt, locale)}</span>
+                                            </div>
+                                        </div>
+                                        <div className="flex shrink-0 items-center gap-4">
+                                            <div className="text-right">
+                                                <p className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                                                    {t("dashboard.recent.seoScoreLabel")}
+                                                </p>
+                                                <p className="text-base font-semibold text-emerald-600 dark:text-emerald-400">
+                                                    {article.seoScore === null || article.seoScore === undefined
+                                                        ? "—"
+                                                        : `${article.seoScore}%`}
+                                                </p>
+                                            </div>
+                                            <ArrowRight className="h-4 w-4 text-slate-300 transition group-hover:translate-x-0.5 group-hover:text-emerald-500 dark:text-slate-600 dark:group-hover:text-emerald-400" />
+                                        </div>
+                                    </Link>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </SectionCard>
+        </PageShell>
     );
 };
 

--- a/frontend/src/app/editor/[id]/page.jsx
+++ b/frontend/src/app/editor/[id]/page.jsx
@@ -63,7 +63,7 @@ const EditorEditPage = ({ params }) => {
 
     if (loadState === "loading") {
         return (
-            <div className="flex h-screen items-center justify-center bg-slate-50 dark:bg-slate-950 text-slate-600 dark:text-slate-400">
+            <div className="flex h-full items-center justify-center bg-slate-50 dark:bg-slate-950 text-slate-600 dark:text-slate-400">
                 <Loader2 className="mr-2 h-5 w-5 animate-spin" />
                 {t("editor.toast.loading")}
             </div>
@@ -72,7 +72,7 @@ const EditorEditPage = ({ params }) => {
 
     if (loadState === "notfound") {
         return (
-            <div className="flex h-screen flex-col items-center justify-center gap-3 bg-slate-50 dark:bg-slate-950 px-6 text-center">
+            <div className="flex h-full flex-col items-center justify-center gap-3 bg-slate-50 dark:bg-slate-950 px-6 text-center">
                 <p className="text-lg text-slate-700 dark:text-slate-200">{t("editor.toast.notFound")}</p>
                 <button
                     type="button"
@@ -87,7 +87,7 @@ const EditorEditPage = ({ params }) => {
 
     if (loadState === "error" || !article) {
         return (
-            <div className="flex h-screen items-center justify-center bg-slate-50 dark:bg-slate-950 text-slate-600 dark:text-slate-400">
+            <div className="flex h-full items-center justify-center bg-slate-50 dark:bg-slate-950 text-slate-600 dark:text-slate-400">
                 {t("editor.toast.loadError")}
             </div>
         );

--- a/frontend/src/app/history/page.jsx
+++ b/frontend/src/app/history/page.jsx
@@ -2,10 +2,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/Card";
 import { Button } from "@/components/Button";
 import { Input } from "@/components/Input";
-import { Badge } from "@/components/Badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/Tabs";
 import {
     Select,
@@ -42,10 +40,16 @@ import {
     Calendar,
     Loader2,
     Plus,
+    FileText,
+    CheckCircle2,
+    PencilLine,
+    Archive,
+    FileSearch,
 } from "lucide-react";
 import { format } from "date-fns";
 import { fr as dateFr, enUS as dateEn } from "date-fns/locale";
 import { toast } from "sonner";
+import { PageShell, PageHeader, StatCard, SectionCard, EmptyState, StatusBadge } from "@/components/ui-kit";
 import { useTranslation } from "@/hooks/useI18n";
 import { API_URL, Urls } from "@/utils/Api";
 
@@ -62,11 +66,11 @@ const TYPE_KEYS = {
     TUTORIAL: "tutorial",
 };
 
-const statusBadgeVariant = {
-    [STATUS_KEYS.PUBLISHED]: "default",
-    [STATUS_KEYS.DRAFT]: "secondary",
-    [STATUS_KEYS.REVIEW]: "outline",
-    [STATUS_KEYS.ARCHIVED]: "secondary",
+const STATUS_BADGE_VARIANT = {
+    [STATUS_KEYS.PUBLISHED]: "published",
+    [STATUS_KEYS.DRAFT]: "draft",
+    [STATUS_KEYS.REVIEW]: "review",
+    [STATUS_KEYS.ARCHIVED]: "archived",
 };
 
 const PublicationsHistory = () => {
@@ -183,205 +187,201 @@ const PublicationsHistory = () => {
     };
 
     return (
-        <div className="flex-1 overflow-auto bg-slate-50 dark:bg-slate-950 p-8">
-            <div className="mx-auto max-w-7xl space-y-8">
-                <div className="flex items-start justify-between gap-4">
-                    <div>
-                        <h1 className="text-3xl">{t("history.title")}</h1>
-                        <p className="text-slate-600 dark:text-slate-400">{t("history.subtitle")}</p>
-                    </div>
-                    <Button onClick={() => router.push("/editor")}>
+        <PageShell>
+            <PageHeader
+                eyebrow={t("history.eyebrow")}
+                title={t("history.title")}
+                description={t("history.subtitle")}
+                actions={
+                    <Button
+                        onClick={() => router.push("/editor")}
+                        className="rounded-lg bg-emerald-600 text-white hover:bg-emerald-700"
+                    >
                         <Plus className="mr-2 h-4 w-4" />
                         {t("history.newArticle")}
                     </Button>
-                </div>
+                }
+            />
 
-                <div className="grid gap-6 md:grid-cols-4">
-                    <Card>
-                        <CardHeader className="pb-3">
-                            <CardDescription>{t("history.stats.total")}</CardDescription>
-                            <CardTitle className="text-3xl">{stats.total}</CardTitle>
-                        </CardHeader>
-                    </Card>
-                    <Card>
-                        <CardHeader className="pb-3">
-                            <CardDescription>{t("history.stats.published")}</CardDescription>
-                            <CardTitle className="text-3xl text-emerald-600">{stats.published}</CardTitle>
-                        </CardHeader>
-                    </Card>
-                    <Card>
-                        <CardHeader className="pb-3">
-                            <CardDescription>{t("history.stats.drafts")}</CardDescription>
-                            <CardTitle className="text-3xl text-amber-600">{stats.draft}</CardTitle>
-                        </CardHeader>
-                    </Card>
-                    <Card>
-                        <CardHeader className="pb-3">
-                            <CardDescription>{t("history.stats.archived")}</CardDescription>
-                            <CardTitle className="text-3xl text-slate-600 dark:text-slate-300">{stats.archived}</CardTitle>
-                        </CardHeader>
-                    </Card>
-                </div>
-
-                <Card>
-                    <CardHeader>
-                        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                            <div>
-                                <CardTitle>{t("history.all")}</CardTitle>
-                                <CardDescription>
-                                    {t("history.resultsCount", { count: filteredArticles.length })}
-                                </CardDescription>
-                            </div>
-                            <div className="flex flex-wrap gap-2">
-                                <div className="relative flex-1 md:w-64 md:flex-none">
-                                    <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400 dark:text-slate-500" />
-                                    <Input
-                                        placeholder={t("history.searchPlaceholder")}
-                                        value={searchQuery}
-                                        onChange={(e) => setSearchQuery(e.target.value)}
-                                        className="pl-9"
-                                    />
-                                </div>
-                                <Select value={filterStatus} onValueChange={setFilterStatus}>
-                                    <SelectTrigger className="w-[140px]">
-                                        <Filter className="mr-2 h-4 w-4" />
-                                        <SelectValue />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value="all">{t("history.filters.allStatus")}</SelectItem>
-                                        <SelectItem value={STATUS_KEYS.PUBLISHED}>{t("history.status.published")}</SelectItem>
-                                        <SelectItem value={STATUS_KEYS.DRAFT}>{t("history.status.draft")}</SelectItem>
-                                        <SelectItem value={STATUS_KEYS.REVIEW}>{t("history.status.review")}</SelectItem>
-                                        <SelectItem value={STATUS_KEYS.ARCHIVED}>{t("history.status.archived")}</SelectItem>
-                                    </SelectContent>
-                                </Select>
-                                <Select value={filterType} onValueChange={setFilterType}>
-                                    <SelectTrigger className="w-[140px]">
-                                        <Filter className="mr-2 h-4 w-4" />
-                                        <SelectValue />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value="all">{t("history.filters.allTypes")}</SelectItem>
-                                        <SelectItem value={TYPE_KEYS.BLOG}>{t("history.type.blog")}</SelectItem>
-                                        <SelectItem value={TYPE_KEYS.GUIDE}>{t("history.type.guide")}</SelectItem>
-                                        <SelectItem value={TYPE_KEYS.TUTORIAL}>{t("history.type.tutorial")}</SelectItem>
-                                    </SelectContent>
-                                </Select>
-                            </div>
-                        </div>
-                    </CardHeader>
-                    <CardContent>
-                        <Tabs defaultValue="list" className="w-full">
-                            <TabsList>
-                                <TabsTrigger value="list">{t("history.tabs.list")}</TabsTrigger>
-                                <TabsTrigger value="calendar">{t("history.tabs.calendar")}</TabsTrigger>
-                            </TabsList>
-
-                            <TabsContent value="list" className="space-y-4">
-                                {loadState === "loading" ? (
-                                    <div className="flex items-center justify-center py-10 text-slate-500 dark:text-slate-400">
-                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                                        {t("history.loading")}
-                                    </div>
-                                ) : loadState === "error" ? (
-                                    <div className="rounded-md bg-red-50 dark:bg-red-950/30 p-3 text-sm text-red-600 dark:text-red-400">
-                                        {t("history.loadError")}
-                                    </div>
-                                ) : articles.length === 0 ? (
-                                    <div className="rounded-md border border-dashed dark:border-slate-700 py-10 text-center text-sm text-slate-500 dark:text-slate-400">
-                                        {t("history.empty")}
-                                    </div>
-                                ) : (
-                                    <div className="space-y-3">
-                                        {filteredArticles.map((article) => (
-                                            <div
-                                                key={article.id}
-                                                className="flex items-center justify-between rounded-lg border dark:border-slate-800 bg-white dark:bg-slate-900 p-4 transition-shadow hover:shadow-md"
-                                            >
-                                                <div className="flex-1 space-y-2">
-                                                    <div className="flex items-center gap-3">
-                                                        <h3 className="font-medium">{article.title}</h3>
-                                                        <Badge variant={statusBadgeVariant[article.status] || "secondary"}>
-                                                            {statusLabel(article.status)}
-                                                        </Badge>
-                                                    </div>
-                                                    <div className="flex flex-wrap items-center gap-4 text-sm text-slate-600 dark:text-slate-400">
-                                                        {article.type && (
-                                                            <>
-                                                                <span>{typeLabel(article.type)}</span>
-                                                                <span>•</span>
-                                                            </>
-                                                        )}
-                                                        <span>
-                                                            {formatDate(article.publishedAt || article.updatedAt)}
-                                                        </span>
-                                                        <span>•</span>
-                                                        <span>{t("history.wordsCount", { count: article.wordCount || 0 })}</span>
-                                                    </div>
-                                                </div>
-                                                <div className="flex items-center gap-4">
-                                                    {typeof article.seoScore === "number" && (
-                                                        <div className="text-right">
-                                                            <p className="text-xs text-slate-500 dark:text-slate-400">{t("history.seoScoreLabel")}</p>
-                                                            <p className="text-lg text-emerald-600">{article.seoScore}%</p>
-                                                        </div>
-                                                    )}
-                                                    <DropdownMenu>
-                                                        <DropdownMenuTrigger asChild>
-                                                            <Button variant="ghost" size="icon">
-                                                                <MoreVertical className="h-4 w-4" />
-                                                            </Button>
-                                                        </DropdownMenuTrigger>
-                                                        <DropdownMenuContent align="end">
-                                                            <DropdownMenuItem onClick={() => router.push(`/editor/${article.id}`)}>
-                                                                <Eye className="mr-2 h-4 w-4" />
-                                                                {t("history.actions.view")}
-                                                            </DropdownMenuItem>
-                                                            <DropdownMenuItem onClick={() => router.push(`/editor/${article.id}`)}>
-                                                                <Edit className="mr-2 h-4 w-4" />
-                                                                {t("history.actions.edit")}
-                                                            </DropdownMenuItem>
-                                                            <DropdownMenuItem disabled>
-                                                                <Download className="mr-2 h-4 w-4" />
-                                                                {t("history.actions.export")}
-                                                            </DropdownMenuItem>
-                                                            <DropdownMenuItem disabled>
-                                                                <Share2 className="mr-2 h-4 w-4" />
-                                                                {t("history.actions.share")}
-                                                            </DropdownMenuItem>
-                                                            <DropdownMenuItem
-                                                                className="text-red-600"
-                                                                onClick={() => setPendingDeleteId(article.id)}
-                                                            >
-                                                                <Trash2 className="mr-2 h-4 w-4" />
-                                                                {t("history.actions.delete")}
-                                                            </DropdownMenuItem>
-                                                        </DropdownMenuContent>
-                                                    </DropdownMenu>
-                                                </div>
-                                            </div>
-                                        ))}
-                                        {filteredArticles.length === 0 && (
-                                            <div className="rounded-md border border-dashed dark:border-slate-700 py-10 text-center text-sm text-slate-500 dark:text-slate-400">
-                                                {t("history.noMatch")}
-                                            </div>
-                                        )}
-                                    </div>
-                                )}
-                            </TabsContent>
-
-                            <TabsContent value="calendar">
-                                <div className="rounded-lg border dark:border-slate-800 bg-white dark:bg-slate-900 p-8 text-center">
-                                    <Calendar className="mx-auto mb-4 h-12 w-12 text-slate-400 dark:text-slate-500" />
-                                    <h3 className="mb-2 text-lg">{t("history.calendar.title")}</h3>
-                                    <p className="text-sm text-slate-600 dark:text-slate-400">{t("history.calendar.description")}</p>
-                                    <p className="mt-4 text-xs text-slate-500 dark:text-slate-400">{t("history.calendar.soon")}</p>
-                                </div>
-                            </TabsContent>
-                        </Tabs>
-                    </CardContent>
-                </Card>
+            <div className="grid gap-4 md:gap-6 grid-cols-2 md:grid-cols-4">
+                <StatCard label={t("history.stats.total")} value={stats.total} icon={FileText} tone="slate" />
+                <StatCard label={t("history.stats.published")} value={stats.published} icon={CheckCircle2} tone="emerald" />
+                <StatCard label={t("history.stats.drafts")} value={stats.draft} icon={PencilLine} tone="amber" />
+                <StatCard label={t("history.stats.archived")} value={stats.archived} icon={Archive} tone="slate" />
             </div>
+
+            <SectionCard
+                title={t("history.all")}
+                description={t("history.resultsCount", { count: filteredArticles.length })}
+                actions={
+                    <div className="flex flex-wrap items-center gap-2">
+                        <div className="relative w-full sm:w-64">
+                            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400 dark:text-slate-500" />
+                            <Input
+                                placeholder={t("history.searchPlaceholder")}
+                                value={searchQuery}
+                                onChange={(e) => setSearchQuery(e.target.value)}
+                                className="pl-9"
+                            />
+                        </div>
+                        <Select value={filterStatus} onValueChange={setFilterStatus}>
+                            <SelectTrigger className="w-[150px]">
+                                <Filter className="mr-2 h-4 w-4 text-slate-400 dark:text-slate-500" />
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="all">{t("history.filters.allStatus")}</SelectItem>
+                                <SelectItem value={STATUS_KEYS.PUBLISHED}>{t("history.status.published")}</SelectItem>
+                                <SelectItem value={STATUS_KEYS.DRAFT}>{t("history.status.draft")}</SelectItem>
+                                <SelectItem value={STATUS_KEYS.REVIEW}>{t("history.status.review")}</SelectItem>
+                                <SelectItem value={STATUS_KEYS.ARCHIVED}>{t("history.status.archived")}</SelectItem>
+                            </SelectContent>
+                        </Select>
+                        <Select value={filterType} onValueChange={setFilterType}>
+                            <SelectTrigger className="w-[150px]">
+                                <Filter className="mr-2 h-4 w-4 text-slate-400 dark:text-slate-500" />
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="all">{t("history.filters.allTypes")}</SelectItem>
+                                <SelectItem value={TYPE_KEYS.BLOG}>{t("history.type.blog")}</SelectItem>
+                                <SelectItem value={TYPE_KEYS.GUIDE}>{t("history.type.guide")}</SelectItem>
+                                <SelectItem value={TYPE_KEYS.TUTORIAL}>{t("history.type.tutorial")}</SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
+                }
+                padding="md"
+            >
+                <Tabs defaultValue="list" className="w-full">
+                    <TabsList>
+                        <TabsTrigger value="list">{t("history.tabs.list")}</TabsTrigger>
+                        <TabsTrigger value="calendar">{t("history.tabs.calendar")}</TabsTrigger>
+                    </TabsList>
+
+                    <TabsContent value="list" className="mt-4">
+                        {loadState === "loading" ? (
+                            <div className="flex items-center justify-center py-12 text-sm text-slate-500 dark:text-slate-400">
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                {t("history.loading")}
+                            </div>
+                        ) : loadState === "error" ? (
+                            <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-400">
+                                {t("history.loadError")}
+                            </div>
+                        ) : articles.length === 0 ? (
+                            <EmptyState
+                                icon={FileText}
+                                title={t("history.emptyTitle")}
+                                description={t("history.empty")}
+                                action={
+                                    <Button
+                                        onClick={() => router.push("/editor")}
+                                        className="rounded-lg bg-emerald-600 text-white hover:bg-emerald-700"
+                                    >
+                                        <Plus className="mr-2 h-4 w-4" />
+                                        {t("history.newArticle")}
+                                    </Button>
+                                }
+                            />
+                        ) : filteredArticles.length === 0 ? (
+                            <EmptyState
+                                icon={FileSearch}
+                                title={t("history.noMatchTitle")}
+                                description={t("history.noMatch")}
+                            />
+                        ) : (
+                            <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+                                {filteredArticles.map((article) => (
+                                    <li
+                                        key={article.id}
+                                        className="flex items-start justify-between gap-4 py-4 first:pt-0 last:pb-0"
+                                    >
+                                        <button
+                                            type="button"
+                                            onClick={() => router.push(`/editor/${article.id}`)}
+                                            className="group min-w-0 flex-1 text-left"
+                                        >
+                                            <div className="flex flex-wrap items-center gap-2">
+                                                <h3 className="text-sm font-semibold text-slate-900 transition group-hover:text-emerald-600 dark:text-slate-100 dark:group-hover:text-emerald-400">
+                                                    {article.title}
+                                                </h3>
+                                                <StatusBadge variant={STATUS_BADGE_VARIANT[article.status] || "draft"}>
+                                                    {statusLabel(article.status)}
+                                                </StatusBadge>
+                                            </div>
+                                            <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
+                                                {article.type && (
+                                                    <>
+                                                        <span>{typeLabel(article.type)}</span>
+                                                        <span aria-hidden>•</span>
+                                                    </>
+                                                )}
+                                                <span>{formatDate(article.publishedAt || article.updatedAt)}</span>
+                                                <span aria-hidden>•</span>
+                                                <span>{t("history.wordsCount", { count: article.wordCount || 0 })}</span>
+                                            </div>
+                                        </button>
+                                        <div className="flex shrink-0 items-center gap-4">
+                                            {typeof article.seoScore === "number" && (
+                                                <div className="hidden text-right sm:block">
+                                                    <p className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                                                        {t("history.seoScoreLabel")}
+                                                    </p>
+                                                    <p className="text-base font-semibold text-emerald-600 dark:text-emerald-400">
+                                                        {article.seoScore}%
+                                                    </p>
+                                                </div>
+                                            )}
+                                            <DropdownMenu>
+                                                <DropdownMenuTrigger asChild>
+                                                    <Button variant="ghost" size="icon" className="rounded-lg">
+                                                        <MoreVertical className="h-4 w-4" />
+                                                    </Button>
+                                                </DropdownMenuTrigger>
+                                                <DropdownMenuContent align="end">
+                                                    <DropdownMenuItem onClick={() => router.push(`/editor/${article.id}`)}>
+                                                        <Eye className="mr-2 h-4 w-4" />
+                                                        {t("history.actions.view")}
+                                                    </DropdownMenuItem>
+                                                    <DropdownMenuItem onClick={() => router.push(`/editor/${article.id}`)}>
+                                                        <Edit className="mr-2 h-4 w-4" />
+                                                        {t("history.actions.edit")}
+                                                    </DropdownMenuItem>
+                                                    <DropdownMenuItem disabled>
+                                                        <Download className="mr-2 h-4 w-4" />
+                                                        {t("history.actions.export")}
+                                                    </DropdownMenuItem>
+                                                    <DropdownMenuItem disabled>
+                                                        <Share2 className="mr-2 h-4 w-4" />
+                                                        {t("history.actions.share")}
+                                                    </DropdownMenuItem>
+                                                    <DropdownMenuItem
+                                                        className="text-red-600 dark:text-red-400"
+                                                        onClick={() => setPendingDeleteId(article.id)}
+                                                    >
+                                                        <Trash2 className="mr-2 h-4 w-4" />
+                                                        {t("history.actions.delete")}
+                                                    </DropdownMenuItem>
+                                                </DropdownMenuContent>
+                                            </DropdownMenu>
+                                        </div>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </TabsContent>
+
+                    <TabsContent value="calendar" className="mt-4">
+                        <EmptyState
+                            icon={Calendar}
+                            title={t("history.calendar.title")}
+                            description={t("history.calendar.description")}
+                            footer={t("history.calendar.soon")}
+                        />
+                    </TabsContent>
+                </Tabs>
+            </SectionCard>
 
             <AlertDialog
                 open={pendingDeleteId !== null}
@@ -398,7 +398,11 @@ const PublicationsHistory = () => {
                     </AlertDialogHeader>
                     <AlertDialogFooter>
                         <AlertDialogCancel disabled={isDeleting}>{t("history.deleteCancel")}</AlertDialogCancel>
-                        <AlertDialogAction onClick={handleDelete} disabled={isDeleting}>
+                        <AlertDialogAction
+                            onClick={handleDelete}
+                            disabled={isDeleting}
+                            className="bg-red-600 text-white hover:bg-red-700"
+                        >
                             {isDeleting ? (
                                 <>
                                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -411,7 +415,7 @@ const PublicationsHistory = () => {
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>
-        </div>
+        </PageShell>
     );
 };
 

--- a/frontend/src/app/ideas/page.jsx
+++ b/frontend/src/app/ideas/page.jsx
@@ -1,15 +1,14 @@
 "use client";
 import { useState } from "react";
 import { useSession } from "next-auth/react";
-import { Copy, RefreshCw, Sparkles, ThumbsDown, ThumbsUp } from "lucide-react";
+import { Copy, RefreshCw, Sparkles, ThumbsDown, ThumbsUp, Lightbulb, Search } from "lucide-react";
 import { toast } from "sonner";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/Card";
 import { Label } from "@/components/Label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/Select";
 import { Textarea } from "@/components/Textarea";
 import { Input } from "@/components/Input";
 import { Button } from "@/components/Button";
-import { Badge } from "@/components/Badge";
+import { PageShell, PageHeader, SectionCard, EmptyState, StatusBadge } from "@/components/ui-kit";
 import { useTranslation } from "@/hooks/useI18n";
 import { API_URL, Urls } from "@/utils/Api";
 
@@ -17,6 +16,12 @@ const DIFFICULTY = {
     EASY: "easy",
     MEDIUM: "medium",
     ADVANCED: "advanced",
+};
+
+const DIFFICULTY_VARIANT = {
+    [DIFFICULTY.EASY]: "easy",
+    [DIFFICULTY.MEDIUM]: "medium",
+    [DIFFICULTY.ADVANCED]: "hard",
 };
 
 const IdeaGenerator = () => {
@@ -90,13 +95,6 @@ const IdeaGenerator = () => {
         toast.success(t("ideas.toast.copied"));
     };
 
-    const difficultyColor = (d) =>
-        d === DIFFICULTY.EASY
-            ? "text-emerald-600"
-            : d === DIFFICULTY.MEDIUM
-                ? "text-amber-600"
-                : "text-red-600";
-
     const difficultyLabel = (d) => {
         const key = `ideas.difficulty.${d}`;
         const translated = t(key);
@@ -104,64 +102,66 @@ const IdeaGenerator = () => {
     };
 
     return (
-        <div className="flex-1 overflow-auto bg-slate-50 dark:bg-slate-950 p-8">
-            <div className="mx-auto max-w-7xl space-y-8">
-                <div>
-                    <h1 className="text-3xl">{t("ideas.title")}</h1>
-                    <p className="text-slate-600 dark:text-slate-400">{t("ideas.subtitle")}</p>
-                </div>
+        <PageShell>
+            <PageHeader
+                eyebrow={t("ideas.eyebrow")}
+                title={t("ideas.title")}
+                description={t("ideas.subtitle")}
+                icon={<Lightbulb className="h-5 w-5" />}
+            />
 
-                <Card>
-                    <CardHeader>
-                        <CardTitle>{t("ideas.configTitle")}</CardTitle>
-                        <CardDescription>{t("ideas.configDescription")}</CardDescription>
-                    </CardHeader>
-                    <CardContent className="space-y-6">
-                        <div className="grid gap-6 md:grid-cols-2">
-                            <div className="space-y-2">
-                                <Label htmlFor="keyword">{t("ideas.mainKeyword")}</Label>
-                                <Input
-                                    id="keyword"
-                                    placeholder={t("ideas.mainKeywordPlaceholder")}
-                                    value={keyword}
-                                    onChange={(e) => setKeyword(e.target.value)}
-                                    maxLength={120}
-                                />
-                            </div>
-
-                            <div className="space-y-2">
-                                <Label htmlFor="content-type">{t("ideas.contentType")}</Label>
-                                <Select value={contentType} onValueChange={setContentType}>
-                                    <SelectTrigger id="content-type">
-                                        <SelectValue placeholder={t("ideas.contentTypePlaceholder")} />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        <SelectItem value="blog">{t("ideas.types.blog")}</SelectItem>
-                                        <SelectItem value="guide">{t("ideas.types.guide")}</SelectItem>
-                                        <SelectItem value="listicle">{t("ideas.types.listicle")}</SelectItem>
-                                        <SelectItem value="tutorial">{t("ideas.types.tutorial")}</SelectItem>
-                                        <SelectItem value="case-study">{t("ideas.types.caseStudy")}</SelectItem>
-                                    </SelectContent>
-                                </Select>
-                            </div>
-                        </div>
-
+            <SectionCard
+                title={t("ideas.configTitle")}
+                description={t("ideas.configDescription")}
+                padding="md"
+            >
+                <div className="space-y-5">
+                    <div className="grid gap-5 md:grid-cols-2">
                         <div className="space-y-2">
-                            <Label htmlFor="audience">{t("ideas.audience")}</Label>
-                            <Textarea
-                                id="audience"
-                                placeholder={t("ideas.audiencePlaceholder")}
-                                value={audience}
-                                onChange={(e) => setAudience(e.target.value)}
-                                rows={3}
-                                maxLength={500}
+                            <Label htmlFor="keyword">{t("ideas.mainKeyword")}</Label>
+                            <Input
+                                id="keyword"
+                                placeholder={t("ideas.mainKeywordPlaceholder")}
+                                value={keyword}
+                                onChange={(e) => setKeyword(e.target.value)}
+                                maxLength={120}
                             />
                         </div>
 
+                        <div className="space-y-2">
+                            <Label htmlFor="content-type">{t("ideas.contentType")}</Label>
+                            <Select value={contentType} onValueChange={setContentType}>
+                                <SelectTrigger id="content-type">
+                                    <SelectValue placeholder={t("ideas.contentTypePlaceholder")} />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="blog">{t("ideas.types.blog")}</SelectItem>
+                                    <SelectItem value="guide">{t("ideas.types.guide")}</SelectItem>
+                                    <SelectItem value="listicle">{t("ideas.types.listicle")}</SelectItem>
+                                    <SelectItem value="tutorial">{t("ideas.types.tutorial")}</SelectItem>
+                                    <SelectItem value="case-study">{t("ideas.types.caseStudy")}</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="audience">{t("ideas.audience")}</Label>
+                        <Textarea
+                            id="audience"
+                            placeholder={t("ideas.audiencePlaceholder")}
+                            value={audience}
+                            onChange={(e) => setAudience(e.target.value)}
+                            rows={3}
+                            maxLength={500}
+                        />
+                    </div>
+
+                    <div className="flex justify-end">
                         <Button
                             onClick={handleGenerate}
                             disabled={isGenerating || keyword.trim().length < 2}
-                            className="w-full md:w-auto"
+                            className="rounded-lg bg-emerald-600 text-white hover:bg-emerald-700"
                         >
                             {isGenerating ? (
                                 <>
@@ -175,78 +175,98 @@ const IdeaGenerator = () => {
                                 </>
                             )}
                         </Button>
-                    </CardContent>
-                </Card>
-
-                {ideas.length === 0 ? (
-                    <div className="rounded-md border border-dashed dark:border-slate-700 py-10 text-center text-sm text-slate-500 dark:text-slate-400">
-                        {t("ideas.empty")}
                     </div>
-                ) : (
-                    <div className="space-y-4">
-                        <div className="flex items-center justify-between">
-                            <h2 className="text-2xl">{t("ideas.suggestionsTitle")}</h2>
-                            <Badge variant="secondary">{t("ideas.ideasCount", { count: ideas.length })}</Badge>
-                        </div>
+                </div>
+            </SectionCard>
 
-                        <div className="grid gap-6">
-                            {ideas.map((idea, index) => (
-                                <Card key={index} className="transition-shadow hover:shadow-md">
-                                    <CardHeader>
-                                        <div className="flex items-start justify-between gap-4">
-                                            <div className="flex-1 space-y-2">
-                                                <CardTitle className="text-xl">{idea.title}</CardTitle>
-                                                <CardDescription>{idea.description}</CardDescription>
-                                            </div>
-                                            <Button
-                                                variant="ghost"
-                                                size="icon"
-                                                onClick={() => handleCopy(idea.title)}
+            {ideas.length === 0 ? (
+                <EmptyState
+                    icon={Sparkles}
+                    title={t("ideas.emptyTitle")}
+                    description={t("ideas.empty")}
+                />
+            ) : (
+                <SectionCard
+                    title={t("ideas.suggestionsTitle")}
+                    description={t("ideas.ideasCount", { count: ideas.length })}
+                    padding="md"
+                >
+                    <div className="grid gap-4">
+                        {ideas.map((idea, index) => (
+                            <article
+                                key={index}
+                                className="rounded-xl border border-slate-200 bg-white p-5 transition hover:border-slate-300 hover:shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-700"
+                            >
+                                <div className="flex items-start justify-between gap-4">
+                                    <div className="min-w-0 flex-1">
+                                        <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+                                            {idea.title}
+                                        </h3>
+                                        {idea.description && (
+                                            <p className="mt-1.5 text-sm text-slate-600 dark:text-slate-400">
+                                                {idea.description}
+                                            </p>
+                                        )}
+                                    </div>
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        onClick={() => handleCopy(idea.title)}
+                                        className="rounded-lg shrink-0"
+                                        aria-label={t("ideas.actions.copy")}
+                                    >
+                                        <Copy className="h-4 w-4" />
+                                    </Button>
+                                </div>
+
+                                {(idea.keywords || []).length > 0 && (
+                                    <div className="mt-3 flex flex-wrap gap-1.5">
+                                        {idea.keywords.map((kw, kIndex) => (
+                                            <span
+                                                key={kIndex}
+                                                className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-300"
                                             >
-                                                <Copy className="h-4 w-4" />
-                                            </Button>
-                                        </div>
-                                    </CardHeader>
-                                    <CardContent>
-                                        <div className="flex flex-wrap items-center gap-4">
-                                            <div className="flex flex-wrap gap-2">
-                                                {(idea.keywords || []).map((kw, kIndex) => (
-                                                    <Badge key={kIndex} variant="outline">
-                                                        {kw}
-                                                    </Badge>
-                                                ))}
+                                                {kw}
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+
+                                <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-slate-100 pt-3 dark:border-slate-800">
+                                    <div className="flex flex-wrap items-center gap-3">
+                                        {idea.difficulty && (
+                                            <div className="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400">
+                                                <span className="font-medium">{t("ideas.difficultyLabel")}</span>
+                                                <StatusBadge variant={DIFFICULTY_VARIANT[idea.difficulty] || "neutral"}>
+                                                    {difficultyLabel(idea.difficulty)}
+                                                </StatusBadge>
                                             </div>
-                                            <div className="ml-auto flex items-center gap-4">
-                                                <div className="text-sm text-slate-600 dark:text-slate-400">
-                                                    <span className="font-medium">{t("ideas.difficultyLabel")}</span>{" "}
-                                                    <span className={difficultyColor(idea.difficulty)}>
-                                                        {difficultyLabel(idea.difficulty)}
-                                                    </span>
-                                                </div>
-                                                {idea.volume && (
-                                                    <div className="text-sm text-slate-600 dark:text-slate-400">
-                                                        <span className="font-medium">{t("ideas.volumeLabel")}</span>{" "}
-                                                        {t("ideas.volumeMonth", { value: idea.volume })}
-                                                    </div>
-                                                )}
-                                                <div className="flex gap-1">
-                                                    <Button variant="ghost" size="icon">
-                                                        <ThumbsUp className="h-4 w-4" />
-                                                    </Button>
-                                                    <Button variant="ghost" size="icon">
-                                                        <ThumbsDown className="h-4 w-4" />
-                                                    </Button>
-                                                </div>
+                                        )}
+                                        {idea.volume && (
+                                            <div className="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400">
+                                                <Search className="h-3.5 w-3.5 text-slate-400 dark:text-slate-500" />
+                                                <span className="font-medium">{t("ideas.volumeLabel")}</span>
+                                                <span className="text-slate-700 dark:text-slate-300">
+                                                    {t("ideas.volumeMonth", { value: idea.volume })}
+                                                </span>
                                             </div>
-                                        </div>
-                                    </CardContent>
-                                </Card>
-                            ))}
-                        </div>
+                                        )}
+                                    </div>
+                                    <div className="flex items-center gap-1">
+                                        <Button variant="ghost" size="icon" className="rounded-lg" aria-label={t("ideas.actions.like")}>
+                                            <ThumbsUp className="h-4 w-4 text-slate-500 dark:text-slate-400" />
+                                        </Button>
+                                        <Button variant="ghost" size="icon" className="rounded-lg" aria-label={t("ideas.actions.dislike")}>
+                                            <ThumbsDown className="h-4 w-4 text-slate-500 dark:text-slate-400" />
+                                        </Button>
+                                    </div>
+                                </div>
+                            </article>
+                        ))}
                     </div>
-                )}
-            </div>
-        </div>
+                </SectionCard>
+            )}
+        </PageShell>
     );
 };
 

--- a/frontend/src/app/page.jsx
+++ b/frontend/src/app/page.jsx
@@ -1,7 +1,5 @@
 "use client";
 import { Button } from "@/components/Button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/Card";
-import { Badge } from "@/components/Badge";
 import {
     Sparkles,
     Zap,
@@ -16,6 +14,7 @@ import {
     Users,
     BarChart3,
     Rocket,
+    PenTool,
 } from "lucide-react";
 import { ImageWithFallback } from "../utils/Image";
 import Link from "next/link";
@@ -25,13 +24,21 @@ const HomePage = ({ onGetStarted }) => {
     const { t } = useTranslation();
 
     const features = [
-        { icon: Sparkles, key: "ai" },
-        { icon: TrendingUp, key: "seo" },
-        { icon: Database, key: "notion" },
-        { icon: Clock, key: "history" },
-        { icon: Share2, key: "multi" },
-        { icon: BarChart3, key: "stats" },
+        { icon: Sparkles, key: "ai", tone: "emerald" },
+        { icon: TrendingUp, key: "seo", tone: "amber" },
+        { icon: Database, key: "notion", tone: "slate" },
+        { icon: Clock, key: "history", tone: "violet" },
+        { icon: Share2, key: "multi", tone: "blue" },
+        { icon: BarChart3, key: "stats", tone: "emerald" },
     ];
+
+    const TONE_MAP = {
+        emerald: "bg-emerald-100 text-emerald-600 dark:bg-emerald-950/40 dark:text-emerald-400",
+        amber: "bg-amber-100 text-amber-600 dark:bg-amber-950/40 dark:text-amber-400",
+        slate: "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300",
+        violet: "bg-violet-100 text-violet-600 dark:bg-violet-950/40 dark:text-violet-400",
+        blue: "bg-blue-100 text-blue-600 dark:bg-blue-950/40 dark:text-blue-400",
+    };
 
     const benefits = [
         t("home.benefits.items.time"),
@@ -75,336 +82,374 @@ const HomePage = ({ onGetStarted }) => {
     ];
 
     return (
-        <div className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-slate-950 dark:to-slate-900">
+        <div className="min-h-screen bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100">
             {/* Navigation */}
-            <nav className="border-b dark:border-slate-800 bg-white/80 dark:bg-slate-950/80 backdrop-blur-sm sticky top-0 z-50">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                    <div className="flex justify-between items-center h-16">
-                        <div className="flex items-center gap-2">
-                            <Sparkles className="w-8 h-8 text-blue-600" />
-                            <span className="text-xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
-                                {t("brand")}
+            <nav className="sticky top-0 z-50 border-b border-slate-200 bg-white/80 backdrop-blur-md dark:border-slate-800 dark:bg-slate-950/80">
+                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+                    <div className="flex h-16 items-center justify-between">
+                        <Link href="/" className="flex items-center gap-2.5">
+                            <span className="grid h-9 w-9 place-items-center rounded-xl bg-emerald-500/15 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-400">
+                                <PenTool className="h-4.5 w-4.5" />
                             </span>
-                        </div>
-                        <div className="hidden md:flex items-center gap-8">
-                            <a href="#features" className="text-gray-600 dark:text-slate-400 hover:text-gray-900 dark:hover:text-slate-100 transition-colors">
+                            <span className="text-base font-semibold tracking-tight">{t("brand")}</span>
+                        </Link>
+                        <div className="hidden md:flex items-center gap-6">
+                            <a href="#features" className="text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 transition-colors">
                                 {t("nav.features")}
                             </a>
-                            <a href="#pricing" className="text-gray-600 dark:text-slate-400 hover:text-gray-900 dark:hover:text-slate-100 transition-colors">
+                            <a href="#pricing" className="text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 transition-colors">
                                 {t("nav.pricing")}
                             </a>
-                            <a href="#testimonials" className="text-gray-600 dark:text-slate-400 hover:text-gray-900 dark:hover:text-slate-100 transition-colors">
+                            <a href="#testimonials" className="text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 transition-colors">
                                 {t("nav.testimonials")}
                             </a>
-                            <Link href="/auth" variant="outline">
+                            <Link
+                                href="/auth"
+                                className="text-sm font-medium text-slate-700 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
+                            >
                                 {t("nav.login")}
                             </Link>
-                            <Button onClick={onGetStarted}>{t("nav.start")}</Button>
+                            <Button asChild className="rounded-lg bg-emerald-600 text-white hover:bg-emerald-700">
+                                <Link href="/auth">{t("nav.start")}</Link>
+                            </Button>
                         </div>
                     </div>
                 </div>
             </nav>
 
-            <section className="relative overflow-hidden pt-20 pb-32">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                    <div className="grid lg:grid-cols-2 gap-12 items-center">
-                        <div className="space-y-8">
-                            <Badge className="bg-blue-100 text-blue-700 hover:bg-blue-100 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-950">
-                                <Rocket className="w-3 h-3 mr-1" />
+            {/* Hero */}
+            <section className="relative overflow-hidden">
+                <div
+                    aria-hidden
+                    className="pointer-events-none absolute -top-32 right-0 h-[28rem] w-[28rem] rounded-full bg-emerald-200/40 blur-3xl dark:bg-emerald-900/20"
+                />
+                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pt-16 md:pt-24 pb-20 md:pb-28">
+                    <div className="grid gap-12 lg:grid-cols-2 lg:items-center">
+                        <div className="space-y-7">
+                            <span className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-300">
+                                <Rocket className="h-3.5 w-3.5" />
                                 {t("home.hero.badge")}
-                            </Badge>
-                            <h1 className="text-5xl lg:text-6xl font-bold leading-tight">
+                            </span>
+                            <h1 className="text-4xl md:text-5xl lg:text-6xl font-semibold leading-[1.1] tracking-tight">
                                 {t("home.hero.title1")}
-                                <span className="bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
-                                    {t("home.hero.title2")}
-                                </span>
+                                <span className="text-emerald-600 dark:text-emerald-400">{t("home.hero.title2")}</span>
                             </h1>
-                            <p className="text-xl text-gray-600 dark:text-slate-400 leading-relaxed">
+                            <p className="text-lg text-slate-600 dark:text-slate-400 leading-relaxed max-w-xl">
                                 {t("home.hero.description")}
                             </p>
-                            <div className="flex flex-col sm:flex-row gap-4">
-                                <Button size="lg" className="gap-2 bg-blue-600 hover:bg-blue-700" onClick={onGetStarted}>
-                                    {t("home.hero.ctaPrimary")}
-                                    <ArrowRight className="w-4 h-4" />
+                            <div className="flex flex-col sm:flex-row gap-3">
+                                <Button asChild size="lg" className="rounded-lg bg-emerald-600 text-white hover:bg-emerald-700 gap-2">
+                                    <Link href="/auth" onClick={onGetStarted}>
+                                        {t("home.hero.ctaPrimary")}
+                                        <ArrowRight className="h-4 w-4" />
+                                    </Link>
                                 </Button>
-                                <Button size="lg" variant="outline" className="gap-2">
-                                    <FileText className="w-4 h-4" />
+                                <Button
+                                    size="lg"
+                                    variant="outline"
+                                    className="rounded-lg border-slate-200 dark:border-slate-800 gap-2"
+                                >
+                                    <FileText className="h-4 w-4" />
                                     {t("home.hero.ctaSecondary")}
                                 </Button>
                             </div>
-                            <div className="flex items-center gap-8 pt-4">
+                            <dl className="grid grid-cols-2 sm:grid-cols-4 gap-4 pt-6 border-t border-slate-200 dark:border-slate-800">
                                 {stats.map((stat, index) => (
-                                    <div key={index} className="text-center">
-                                        <div className="text-2xl font-bold text-gray-900 dark:text-slate-100">{stat.value}</div>
-                                        <div className="text-sm text-gray-600 dark:text-slate-400">{t(stat.labelKey)}</div>
+                                    <div key={index}>
+                                        <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                                            {t(stat.labelKey)}
+                                        </dt>
+                                        <dd className="mt-1 text-2xl font-semibold text-slate-900 dark:text-slate-100">
+                                            {stat.value}
+                                        </dd>
                                     </div>
                                 ))}
-                            </div>
+                            </dl>
                         </div>
                         <div className="relative">
-                            <div className="absolute inset-0 bg-gradient-to-tr from-blue-600/20 to-purple-600/20 rounded-3xl blur-3xl"></div>
-                            <ImageWithFallback
-                                src="https://images.unsplash.com/photo-1676287571987-2f98ced3e6c4?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxhaSUyMGNvbnRlbnQlMjB3cml0aW5nJTIwbWFya2V0aW5nfGVufDF8fHx8MTc3NTEzMzk3M3ww&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral"
-                                alt="AI Content Creation"
-                                className="relative rounded-2xl shadow-2xl w-full object-cover"
-                            />
+                            <div className="absolute -inset-4 rounded-3xl bg-gradient-to-tr from-emerald-200/40 to-transparent blur-2xl dark:from-emerald-900/20" />
+                            <div className="relative overflow-hidden rounded-2xl border border-slate-200 shadow-xl dark:border-slate-800">
+                                <ImageWithFallback
+                                    src="https://images.unsplash.com/photo-1676287571987-2f98ced3e6c4?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxhaSUyMGNvbnRlbnQlMjB3cml0aW5nJTIwbWFya2V0aW5nfGVufDF8fHx8MTc3NTEzMzk3M3ww&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral"
+                                    alt="AI Content Creation"
+                                    className="w-full object-cover"
+                                />
+                            </div>
                         </div>
                     </div>
                 </div>
             </section>
 
-            {/* Features Section */}
-            <section id="features" className="py-20 bg-white dark:bg-slate-950">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                    <div className="text-center mb-16">
-                        <Badge className="mb-4 bg-purple-100 text-purple-700 hover:bg-purple-100 dark:bg-purple-950 dark:text-purple-300 dark:hover:bg-purple-950">
+            {/* Features */}
+            <section id="features" className="border-t border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/30 py-20">
+                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+                    <div className="mx-auto max-w-2xl text-center">
+                        <p className="text-xs font-medium uppercase tracking-wide text-emerald-600 dark:text-emerald-400">
                             {t("home.features.badge")}
-                        </Badge>
-                        <h2 className="text-4xl font-bold mb-4">{t("home.features.title")}</h2>
-                        <p className="text-xl text-gray-600 dark:text-slate-400 max-w-2xl mx-auto">
+                        </p>
+                        <h2 className="mt-2 text-3xl md:text-4xl font-semibold tracking-tight">
+                            {t("home.features.title")}
+                        </h2>
+                        <p className="mt-3 text-lg text-slate-600 dark:text-slate-400">
                             {t("home.features.subtitle")}
                         </p>
                     </div>
 
-                    <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+                    <div className="mt-14 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
                         {features.map((feature, index) => {
                             const Icon = feature.icon;
                             return (
-                                <Card
+                                <article
                                     key={index}
-                                    className="border-2 dark:border-slate-800 hover:border-blue-200 dark:hover:border-blue-900 hover:shadow-lg transition-all duration-300"
+                                    className="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:border-emerald-200 hover:shadow-md dark:border-slate-800 dark:bg-slate-900 dark:hover:border-emerald-900/40"
                                 >
-                                    <CardHeader>
-                                        <div className="w-12 h-12 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center mb-4">
-                                            <Icon className="w-6 h-6 text-white" />
-                                        </div>
-                                        <CardTitle className="text-xl">
-                                            {t(`home.features.items.${feature.key}.title`)}
-                                        </CardTitle>
-                                    </CardHeader>
-                                    <CardContent>
-                                        <CardDescription className="text-base">
-                                            {t(`home.features.items.${feature.key}.description`)}
-                                        </CardDescription>
-                                    </CardContent>
-                                </Card>
+                                    <span className={`mb-4 grid h-11 w-11 place-items-center rounded-xl transition group-hover:scale-105 ${TONE_MAP[feature.tone]}`}>
+                                        <Icon className="h-5 w-5" />
+                                    </span>
+                                    <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+                                        {t(`home.features.items.${feature.key}.title`)}
+                                    </h3>
+                                    <p className="mt-2 text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+                                        {t(`home.features.items.${feature.key}.description`)}
+                                    </p>
+                                </article>
                             );
                         })}
                     </div>
                 </div>
             </section>
 
-            {/* Benefits Section */}
-            <section className="py-20 bg-gradient-to-br from-blue-50 to-purple-50 dark:from-slate-900 dark:to-slate-950">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                    <div className="grid lg:grid-cols-2 gap-12 items-center">
+            {/* Benefits */}
+            <section className="py-20">
+                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+                    <div className="grid gap-12 lg:grid-cols-2 lg:items-center">
                         <div className="relative">
-                            <ImageWithFallback
-                                src="https://images.unsplash.com/photo-1686061594225-3e92c0cd51b0?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxzZW8lMjBhbmFseXRpY3MlMjBkYXNoYm9hcmR8ZW58MXx8fHwxNzc1MTMzOTc0fDA&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral"
-                                alt="Analytics Dashboard"
-                                className="rounded-2xl shadow-2xl w-full object-cover"
-                            />
+                            <div className="absolute -inset-4 rounded-3xl bg-gradient-to-br from-emerald-200/40 to-transparent blur-2xl dark:from-emerald-900/20" />
+                            <div className="relative overflow-hidden rounded-2xl border border-slate-200 shadow-xl dark:border-slate-800">
+                                <ImageWithFallback
+                                    src="https://images.unsplash.com/photo-1686061594225-3e92c0cd51b0?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxzZW8lMjBhbmFseXRpY3MlMjBkYXNoYm9hcmR8ZW58MXx8fHwxNzc1MTMzOTc0fDA&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral"
+                                    alt="Analytics Dashboard"
+                                    className="w-full object-cover"
+                                />
+                            </div>
                         </div>
                         <div className="space-y-6">
-                            <Badge className="bg-green-100 text-green-700 hover:bg-green-100 dark:bg-green-950 dark:text-green-300 dark:hover:bg-green-950">
-                                <Zap className="w-3 h-3 mr-1" />
+                            <span className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-300">
+                                <Zap className="h-3.5 w-3.5" />
                                 {t("home.benefits.badge")}
-                            </Badge>
-                            <h2 className="text-4xl font-bold">{t("home.benefits.title")}</h2>
-                            <p className="text-lg text-gray-600 dark:text-slate-400">{t("home.benefits.subtitle")}</p>
-                            <ul className="space-y-4">
+                            </span>
+                            <h2 className="text-3xl md:text-4xl font-semibold tracking-tight">{t("home.benefits.title")}</h2>
+                            <p className="text-lg text-slate-600 dark:text-slate-400">{t("home.benefits.subtitle")}</p>
+                            <ul className="space-y-3">
                                 {benefits.map((benefit, index) => (
                                     <li key={index} className="flex items-start gap-3">
-                                        <CheckCircle2 className="w-6 h-6 text-green-600 flex-shrink-0 mt-0.5" />
-                                        <span className="text-lg text-gray-700 dark:text-slate-300">{benefit}</span>
+                                        <span className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-950/40 dark:text-emerald-400">
+                                            <CheckCircle2 className="h-3.5 w-3.5" />
+                                        </span>
+                                        <span className="text-base text-slate-700 dark:text-slate-300">{benefit}</span>
                                     </li>
                                 ))}
                             </ul>
-                            <Button size="lg" className="gap-2 bg-green-600 hover:bg-green-700" onClick={onGetStarted}>
-                                {t("home.benefits.cta")}
-                                <ArrowRight className="w-4 h-4" />
+                            <Button asChild size="lg" className="rounded-lg bg-emerald-600 text-white hover:bg-emerald-700 gap-2">
+                                <Link href="/auth" onClick={onGetStarted}>
+                                    {t("home.benefits.cta")}
+                                    <ArrowRight className="h-4 w-4" />
+                                </Link>
                             </Button>
                         </div>
                     </div>
                 </div>
             </section>
 
-            {/* Testimonials Section */}
-            <section id="testimonials" className="py-20 bg-white dark:bg-slate-950">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                    <div className="text-center mb-16">
-                        <Badge className="mb-4 bg-yellow-100 text-yellow-700 hover:bg-yellow-100 dark:bg-yellow-950 dark:text-yellow-300 dark:hover:bg-yellow-950">
-                            <Users className="w-3 h-3 mr-1" />
+            {/* Testimonials */}
+            <section id="testimonials" className="border-t border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/30 py-20">
+                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+                    <div className="mx-auto max-w-2xl text-center">
+                        <span className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-300">
+                            <Users className="h-3.5 w-3.5" />
                             {t("home.testimonials.badge")}
-                        </Badge>
-                        <h2 className="text-4xl font-bold mb-4">{t("home.testimonials.title")}</h2>
-                        <p className="text-xl text-gray-600 dark:text-slate-400 max-w-2xl mx-auto">
-                            {t("home.testimonials.subtitle")}
-                        </p>
+                        </span>
+                        <h2 className="mt-3 text-3xl md:text-4xl font-semibold tracking-tight">{t("home.testimonials.title")}</h2>
+                        <p className="mt-3 text-lg text-slate-600 dark:text-slate-400">{t("home.testimonials.subtitle")}</p>
                     </div>
 
-                    <div className="grid md:grid-cols-3 gap-8">
+                    <div className="mt-14 grid gap-5 md:grid-cols-3">
                         {testimonials.map((testimonial) => (
-                            <Card key={testimonial.key} className="border-2 dark:border-slate-800 hover:shadow-xl transition-all duration-300">
-                                <CardHeader>
-                                    <div className="flex gap-1 mb-3">
-                                        {[...Array(testimonial.rating)].map((_, i) => (
-                                            <Star key={i} className="w-5 h-5 fill-yellow-400 text-yellow-400" />
-                                        ))}
-                                    </div>
-                                    <CardDescription className="text-base italic">
-                                        "{testimonial.content}"
-                                    </CardDescription>
-                                </CardHeader>
-                                <CardContent>
-                                    <div>
-                                        <div className="font-semibold text-gray-900 dark:text-slate-100">{testimonial.name}</div>
-                                        <div className="text-sm text-gray-600 dark:text-slate-400">
-                                            {t("home.testimonials.roleAt", {
-                                                role: testimonial.role,
-                                                company: testimonial.company,
-                                            })}
-                                        </div>
-                                    </div>
-                                </CardContent>
-                            </Card>
+                            <article
+                                key={testimonial.key}
+                                className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900"
+                            >
+                                <div className="flex gap-0.5">
+                                    {[...Array(testimonial.rating)].map((_, i) => (
+                                        <Star key={i} className="h-4 w-4 fill-amber-400 text-amber-400" />
+                                    ))}
+                                </div>
+                                <p className="mt-4 text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+                                    {testimonial.content}
+                                </p>
+                                <div className="mt-5 border-t border-slate-100 pt-4 dark:border-slate-800">
+                                    <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                                        {testimonial.name}
+                                    </p>
+                                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                                        {t("home.testimonials.roleAt", {
+                                            role: testimonial.role,
+                                            company: testimonial.company,
+                                        })}
+                                    </p>
+                                </div>
+                            </article>
                         ))}
                     </div>
                 </div>
             </section>
 
-            {/* Pricing Section */}
-            <section id="pricing" className="py-20 bg-gradient-to-b from-gray-50 to-white dark:from-slate-950 dark:to-slate-900">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                    <div className="text-center mb-16">
-                        <Badge className="mb-4 bg-blue-100 text-blue-700 hover:bg-blue-100 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-950">
+            {/* Pricing */}
+            <section id="pricing" className="py-20">
+                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+                    <div className="mx-auto max-w-2xl text-center">
+                        <p className="text-xs font-medium uppercase tracking-wide text-emerald-600 dark:text-emerald-400">
                             {t("home.pricing.badge")}
-                        </Badge>
-                        <h2 className="text-4xl font-bold mb-4">{t("home.pricing.title")}</h2>
-                        <p className="text-xl text-gray-600 dark:text-slate-400 max-w-2xl mx-auto">
-                            {t("home.pricing.subtitle")}
                         </p>
+                        <h2 className="mt-2 text-3xl md:text-4xl font-semibold tracking-tight">{t("home.pricing.title")}</h2>
+                        <p className="mt-3 text-lg text-slate-600 dark:text-slate-400">{t("home.pricing.subtitle")}</p>
                     </div>
 
-                    <div className="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
+                    <div className="mt-14 grid gap-6 md:grid-cols-3 lg:gap-8 max-w-6xl mx-auto">
                         {pricingPlans.map((plan) => (
-                            <Card
+                            <article
                                 key={plan.key}
-                                className={`relative ${
+                                className={`relative flex flex-col rounded-2xl border bg-white p-7 shadow-sm transition hover:shadow-lg dark:bg-slate-900 ${
                                     plan.highlighted
-                                        ? "border-4 border-blue-600 shadow-2xl scale-105"
-                                        : "border-2"
+                                        ? "border-emerald-500 ring-1 ring-emerald-500/30 lg:scale-[1.03]"
+                                        : "border-slate-200 dark:border-slate-800"
                                 }`}
                             >
                                 {plan.highlighted && (
-                                    <div className="absolute -top-4 left-1/2 -translate-x-1/2">
-                                        <Badge className="bg-blue-600 text-white hover:bg-blue-600">
-                                            {t("home.pricing.popular")}
-                                        </Badge>
-                                    </div>
+                                    <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-emerald-600 px-3 py-1 text-xs font-semibold text-white shadow-sm">
+                                        {t("home.pricing.popular")}
+                                    </span>
                                 )}
-                                <CardHeader>
-                                    <CardTitle className="text-2xl">
-                                        {t(`home.pricing.plans.${plan.key}.name`)}
-                                    </CardTitle>
-                                    <CardDescription>
-                                        {t(`home.pricing.plans.${plan.key}.description`)}
-                                    </CardDescription>
-                                    <div className="mt-4">
-                                        <span className="text-4xl font-bold">
-                                            {t(`home.pricing.plans.${plan.key}.price`)}
-                                        </span>
-                                        <span className="text-gray-600 dark:text-slate-400">{t("home.pricing.period")}</span>
-                                    </div>
-                                </CardHeader>
-                                <CardContent>
-                                    <ul className="space-y-3 mb-6">
-                                        {plan.features.map((featureKey) => (
-                                            <li key={featureKey} className="flex items-start gap-2">
-                                                <CheckCircle2 className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" />
-                                                <span className="text-gray-700 dark:text-slate-300">
-                                                    {t(`home.pricing.plans.${plan.key}.features.${featureKey}`)}
-                                                </span>
-                                            </li>
-                                        ))}
-                                    </ul>
-                                    <Button
-                                        className={`w-full ${
-                                            plan.highlighted ? "bg-blue-600 hover:bg-blue-700" : ""
-                                        }`}
-                                        variant={plan.highlighted ? "default" : "outline"}
-                                        size="lg"
-                                        onClick={onGetStarted}
-                                    >
+                                <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+                                    {t(`home.pricing.plans.${plan.key}.name`)}
+                                </h3>
+                                <p className="mt-1.5 text-sm text-slate-600 dark:text-slate-400">
+                                    {t(`home.pricing.plans.${plan.key}.description`)}
+                                </p>
+                                <div className="mt-5">
+                                    <span className="text-4xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+                                        {t(`home.pricing.plans.${plan.key}.price`)}
+                                    </span>
+                                    <span className="text-sm text-slate-500 dark:text-slate-400">
+                                        {t("home.pricing.period")}
+                                    </span>
+                                </div>
+                                <ul className="mt-6 space-y-2.5 flex-1">
+                                    {plan.features.map((featureKey) => (
+                                        <li key={featureKey} className="flex items-start gap-2.5 text-sm">
+                                            <CheckCircle2 className="h-4 w-4 shrink-0 mt-0.5 text-emerald-600 dark:text-emerald-400" />
+                                            <span className="text-slate-700 dark:text-slate-300">
+                                                {t(`home.pricing.plans.${plan.key}.features.${featureKey}`)}
+                                            </span>
+                                        </li>
+                                    ))}
+                                </ul>
+                                <Button
+                                    asChild
+                                    size="lg"
+                                    className={`mt-7 w-full rounded-lg ${
+                                        plan.highlighted
+                                            ? "bg-emerald-600 text-white hover:bg-emerald-700"
+                                            : ""
+                                    }`}
+                                    variant={plan.highlighted ? "default" : "outline"}
+                                >
+                                    <Link href="/auth" onClick={onGetStarted}>
                                         {plan.highlighted
                                             ? t("home.pricing.ctaPopular")
                                             : t("home.pricing.ctaNormal")}
-                                    </Button>
-                                </CardContent>
-                            </Card>
+                                    </Link>
+                                </Button>
+                            </article>
                         ))}
                     </div>
                 </div>
             </section>
 
-            {/* CTA Section */}
-            <section className="py-20 bg-gradient-to-r from-blue-600 to-purple-600 text-white">
-                <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-                    <h2 className="text-4xl font-bold mb-6">{t("home.cta.title")}</h2>
-                    <p className="text-xl mb-8 text-blue-100">{t("home.cta.subtitle")}</p>
-                    <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                        <Button size="lg" className="bg-white text-blue-600 hover:bg-gray-100 gap-2" onClick={onGetStarted}>
-                            {t("home.cta.ctaPrimary")}
-                            <ArrowRight className="w-4 h-4" />
-                        </Button>
-                        <Button size="lg" variant="outline" className="border-white text-white hover:bg-white/10">
-                            {t("home.cta.ctaSecondary")}
-                        </Button>
+            {/* CTA */}
+            <section className="border-t border-slate-200 dark:border-slate-800 py-20">
+                <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+                    <div className="relative overflow-hidden rounded-3xl bg-slate-900 px-8 py-14 text-center text-white shadow-xl dark:bg-slate-950 dark:ring-1 dark:ring-slate-800">
+                        <div
+                            aria-hidden
+                            className="pointer-events-none absolute -top-32 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-emerald-500/30 blur-3xl"
+                        />
+                        <div className="relative">
+                            <h2 className="text-3xl md:text-4xl font-semibold tracking-tight">{t("home.cta.title")}</h2>
+                            <p className="mt-3 text-base text-slate-300 max-w-2xl mx-auto">{t("home.cta.subtitle")}</p>
+                            <div className="mt-7 flex flex-col sm:flex-row gap-3 justify-center">
+                                <Button asChild size="lg" className="rounded-lg bg-emerald-500 text-white hover:bg-emerald-400 gap-2">
+                                    <Link href="/auth" onClick={onGetStarted}>
+                                        {t("home.cta.ctaPrimary")}
+                                        <ArrowRight className="h-4 w-4" />
+                                    </Link>
+                                </Button>
+                                <Button
+                                    size="lg"
+                                    variant="outline"
+                                    className="rounded-lg border-slate-700 text-white hover:bg-slate-800"
+                                >
+                                    {t("home.cta.ctaSecondary")}
+                                </Button>
+                            </div>
+                            <p className="mt-5 text-xs text-slate-400">{t("home.cta.note")}</p>
+                        </div>
                     </div>
-                    <p className="mt-6 text-blue-100">{t("home.cta.note")}</p>
                 </div>
             </section>
 
             {/* Footer */}
-            <footer className="bg-gray-900 text-gray-300 py-12">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                    <div className="grid md:grid-cols-4 gap-8 mb-8">
+            <footer className="border-t border-slate-200 bg-white py-14 dark:border-slate-800 dark:bg-slate-900/30">
+                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+                    <div className="grid gap-8 md:grid-cols-4 mb-10">
                         <div>
-                            <div className="flex items-center gap-2 mb-4">
-                                <Sparkles className="w-6 h-6 text-blue-500" />
-                                <span className="font-bold text-white">{t("brand")}</span>
-                            </div>
-                            <p className="text-sm">{t("home.footer.tagline")}</p>
+                            <Link href="/" className="flex items-center gap-2.5 mb-3">
+                                <span className="grid h-9 w-9 place-items-center rounded-xl bg-emerald-500/15 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-400">
+                                    <PenTool className="h-4.5 w-4.5" />
+                                </span>
+                                <span className="font-semibold tracking-tight text-slate-900 dark:text-slate-100">{t("brand")}</span>
+                            </Link>
+                            <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">{t("home.footer.tagline")}</p>
                         </div>
                         <div>
-                            <h3 className="font-semibold text-white mb-4">{t("home.footer.productCol")}</h3>
+                            <h3 className="font-semibold text-slate-900 dark:text-slate-100 mb-3 text-sm">{t("home.footer.productCol")}</h3>
                             <ul className="space-y-2 text-sm">
-                                <li><a href="#" className="hover:text-white transition-colors">{t("home.footer.product.features")}</a></li>
-                                <li><a href="#" className="hover:text-white transition-colors">{t("home.footer.product.pricing")}</a></li>
-                                <li><a href="#" className="hover:text-white transition-colors">{t("home.footer.product.integrations")}</a></li>
-                                <li><a href="#" className="hover:text-white transition-colors">{t("home.footer.product.api")}</a></li>
+                                <li><a href="#" className="text-slate-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{t("home.footer.product.features")}</a></li>
+                                <li><a href="#" className="text-slate-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{t("home.footer.product.pricing")}</a></li>
+                                <li><a href="#" className="text-slate-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{t("home.footer.product.integrations")}</a></li>
+                                <li><a href="#" className="text-slate-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{t("home.footer.product.api")}</a></li>
                             </ul>
                         </div>
                         <div>
-                            <h3 className="font-semibold text-white mb-4">{t("home.footer.resourcesCol")}</h3>
+                            <h3 className="font-semibold text-slate-900 dark:text-slate-100 mb-3 text-sm">{t("home.footer.resourcesCol")}</h3>
                             <ul className="space-y-2 text-sm">
-                                <li><a href="#" className="hover:text-white transition-colors">{t("home.footer.resources.docs")}</a></li>
-                                <li><a href="#" className="hover:text-white transition-colors">{t("home.footer.resources.blog")}</a></li>
-                                <li><a href="#" className="hover:text-white transition-colors">{t("home.footer.resources.guides")}</a></li>
-                                <li><a href="#" className="hover:text-white transition-colors">{t("home.footer.resources.support")}</a></li>
+                                <li><a href="#" className="text-slate-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{t("home.footer.resources.docs")}</a></li>
+                                <li><a href="#" className="text-slate-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{t("home.footer.resources.blog")}</a></li>
+                                <li><a href="#" className="text-slate-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{t("home.footer.resources.guides")}</a></li>
+                                <li><a href="#" className="text-slate-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{t("home.footer.resources.support")}</a></li>
                             </ul>
                         </div>
                         <div>
-                            <h3 className="font-semibold text-white mb-4">{t("home.footer.companyCol")}</h3>
+                            <h3 className="font-semibold text-slate-900 dark:text-slate-100 mb-3 text-sm">{t("home.footer.companyCol")}</h3>
                             <ul className="space-y-2 text-sm">
-                                <li><a href="#" className="hover:text-white transition-colors">{t("home.footer.company.about")}</a></li>
-                                <li><a href="#" className="hover:text-white transition-colors">{t("home.footer.company.contact")}</a></li>
-                                <li><a href="#" className="hover:text-white transition-colors">{t("home.footer.company.legal")}</a></li>
-                                <li><a href="#" className="hover:text-white transition-colors">{t("home.footer.company.privacy")}</a></li>
+                                <li><a href="#" className="text-slate-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{t("home.footer.company.about")}</a></li>
+                                <li><a href="#" className="text-slate-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{t("home.footer.company.contact")}</a></li>
+                                <li><a href="#" className="text-slate-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{t("home.footer.company.legal")}</a></li>
+                                <li><a href="#" className="text-slate-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">{t("home.footer.company.privacy")}</a></li>
                             </ul>
                         </div>
                     </div>
-                    <div className="border-t border-gray-800 pt-8 text-center text-sm">
+                    <div className="border-t border-slate-200 dark:border-slate-800 pt-6 text-center text-xs text-slate-500 dark:text-slate-400">
                         <p>{t("home.footer.copyright")}</p>
                     </div>
                 </div>

--- a/frontend/src/app/settings/page.jsx
+++ b/frontend/src/app/settings/page.jsx
@@ -1,7 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
 import { useSession } from "next-auth/react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/Card";
 import { Button } from "@/components/Button";
 import { Input } from "@/components/Input";
 import { Label } from "@/components/Label";
@@ -9,9 +8,9 @@ import { Separator } from "@/components/Separator";
 import { Switch } from "@/components/Switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/Tabs";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/Select";
-import { Badge } from "@/components/Badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/Avatar";
-import { Bell, Check, Link as LinkIcon, Loader2, Palette, Shield, Sparkles, User, X } from "lucide-react";
+import { Bell, Check, Link as LinkIcon, Loader2, Palette, Shield, Sparkles, User, X, KeyRound, Moon } from "lucide-react";
+import { PageShell, PageHeader, SectionCard, StatusBadge } from "@/components/ui-kit";
 import { toast } from "sonner";
 import { useTheme } from "next-themes";
 import { useTranslation } from "@/hooks/useI18n";
@@ -436,64 +435,65 @@ const Settings = () => {
     }
 
     return (
-        <div className="flex-1 overflow-auto bg-slate-50 dark:bg-slate-950 p-8">
-            <div className="mx-auto max-w-5xl space-y-8">
-                <div>
-                    <h1 className="text-3xl">{t("settings.title")}</h1>
-                    <p className="text-slate-600 dark:text-slate-400">{t("settings.subTitle")}</p>
-                </div>
+        <PageShell>
+            <PageHeader
+                eyebrow={t("settings.eyebrow")}
+                title={t("settings.title")}
+                description={t("settings.subTitle")}
+            />
 
-                <Tabs defaultValue="profile" className="w-full">
-                    <TabsList>
-                        <TabsTrigger value="profile">
-                            <User className="mr-2 h-4 w-4" />
-                            {t("settings.tabs.profile")}
-                        </TabsTrigger>
-                        <TabsTrigger value="integrations">
-                            <LinkIcon className="mr-2 h-4 w-4" />
-                            {t("settings.tabs.integrations")}
-                        </TabsTrigger>
-                        <TabsTrigger value="notifications">
-                            <Bell className="mr-2 h-4 w-4" />
-                            {t("settings.tabs.notifications")}
-                        </TabsTrigger>
-                        <TabsTrigger value="security">
-                            <Shield className="mr-2 h-4 w-4" />
-                            {t("settings.tabs.security")}
-                        </TabsTrigger>
-                        <TabsTrigger value="preferences">
-                            <Palette className="mr-2 h-4 w-4" />
-                            {t("settings.tabs.preferences")}
-                        </TabsTrigger>
-                    </TabsList>
+            <Tabs defaultValue="profile" className="w-full space-y-6">
+                <TabsList className="flex w-full flex-wrap justify-start gap-1 bg-white p-1 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl h-auto">
+                    <TabsTrigger value="profile" className="data-[state=active]:bg-emerald-50 data-[state=active]:text-emerald-700 dark:data-[state=active]:bg-emerald-950/40 dark:data-[state=active]:text-emerald-300">
+                        <User className="mr-2 h-4 w-4" />
+                        {t("settings.tabs.profile")}
+                    </TabsTrigger>
+                    <TabsTrigger value="integrations" className="data-[state=active]:bg-emerald-50 data-[state=active]:text-emerald-700 dark:data-[state=active]:bg-emerald-950/40 dark:data-[state=active]:text-emerald-300">
+                        <LinkIcon className="mr-2 h-4 w-4" />
+                        {t("settings.tabs.integrations")}
+                    </TabsTrigger>
+                    <TabsTrigger value="notifications" className="data-[state=active]:bg-emerald-50 data-[state=active]:text-emerald-700 dark:data-[state=active]:bg-emerald-950/40 dark:data-[state=active]:text-emerald-300">
+                        <Bell className="mr-2 h-4 w-4" />
+                        {t("settings.tabs.notifications")}
+                    </TabsTrigger>
+                    <TabsTrigger value="security" className="data-[state=active]:bg-emerald-50 data-[state=active]:text-emerald-700 dark:data-[state=active]:bg-emerald-950/40 dark:data-[state=active]:text-emerald-300">
+                        <Shield className="mr-2 h-4 w-4" />
+                        {t("settings.tabs.security")}
+                    </TabsTrigger>
+                    <TabsTrigger value="preferences" className="data-[state=active]:bg-emerald-50 data-[state=active]:text-emerald-700 dark:data-[state=active]:bg-emerald-950/40 dark:data-[state=active]:text-emerald-300">
+                        <Palette className="mr-2 h-4 w-4" />
+                        {t("settings.tabs.preferences")}
+                    </TabsTrigger>
+                </TabsList>
 
-                    <TabsContent value="profile" className="space-y-6">
-                        <Card>
-                            <CardHeader>
-                                <CardTitle>{t("settings.profile.title")}</CardTitle>
-                                <CardDescription>{t("settings.profile.description")}</CardDescription>
-                            </CardHeader>
-                            <CardContent className="space-y-6">
-                                <div className="flex items-center gap-6">
-                                    <Avatar className="h-20 w-20">
-                                        <AvatarImage src={avatar || ""} alt={name} />
-                                        <AvatarFallback className="text-lg">{initialsOf(name)}</AvatarFallback>
-                                    </Avatar>
-                                    <div className="flex-1 space-y-2">
-                                        <Label htmlFor="avatarUrl" className="text-xs">{t("settings.profile.avatarUrl")}</Label>
-                                        <Input
-                                            id="avatarUrl"
-                                            value={avatar}
-                                            onChange={(e) => setAvatar(e.target.value)}
-                                            placeholder="https://..."
-                                            maxLength={500}
-                                        />
-                                        <p className="text-xs text-slate-500 dark:text-slate-400">{t("settings.profile.avatarHint")}</p>
-                                    </div>
+                <TabsContent value="profile" className="space-y-6 mt-0">
+                    <SectionCard
+                        title={t("settings.profile.title")}
+                        description={t("settings.profile.description")}
+                        padding="md"
+                    >
+                        <div className="space-y-6">
+                            <div className="flex flex-col items-start gap-6 md:flex-row md:items-center">
+                                <Avatar className="h-20 w-20 ring-2 ring-emerald-100 dark:ring-emerald-950/40">
+                                    <AvatarImage src={avatar || ""} alt={name} />
+                                    <AvatarFallback className="bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300 text-lg font-semibold">
+                                        {initialsOf(name)}
+                                    </AvatarFallback>
+                                </Avatar>
+                                <div className="flex-1 w-full space-y-2">
+                                    <Label htmlFor="avatarUrl" className="text-xs">{t("settings.profile.avatarUrl")}</Label>
+                                    <Input
+                                        id="avatarUrl"
+                                        value={avatar}
+                                        onChange={(e) => setAvatar(e.target.value)}
+                                        placeholder="https://..."
+                                        maxLength={500}
+                                    />
+                                    <p className="text-xs text-slate-500 dark:text-slate-400">{t("settings.profile.avatarHint")}</p>
                                 </div>
+                            </div>
 
-                                <Separator />
-
+                            <div className="grid gap-4 md:grid-cols-2">
                                 <div className="space-y-2">
                                     <Label htmlFor="name">{t("form.name")}</Label>
                                     <Input
@@ -503,7 +503,6 @@ const Settings = () => {
                                         maxLength={100}
                                     />
                                 </div>
-
                                 <div className="space-y-2">
                                     <Label htmlFor="email">{t("form.email")}</Label>
                                     <Input
@@ -514,340 +513,348 @@ const Settings = () => {
                                         maxLength={255}
                                     />
                                 </div>
+                            </div>
 
+                            <div className="space-y-2">
+                                <Label htmlFor="bio">{t("form.bio")}</Label>
+                                <Input
+                                    id="bio"
+                                    placeholder={t("settings.profile.bioPlaceholder")}
+                                    value={bio}
+                                    onChange={(e) => setBio(e.target.value)}
+                                    maxLength={1000}
+                                />
+                            </div>
+
+                            <div className="flex justify-end pt-2">
+                                <Button
+                                    onClick={handleSaveProfile}
+                                    disabled={isSavingProfile}
+                                    className="rounded-lg bg-emerald-600 text-white hover:bg-emerald-700"
+                                >
+                                    {isSavingProfile && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                    {t("common.save")}
+                                </Button>
+                            </div>
+                        </div>
+                    </SectionCard>
+
+                    <SectionCard
+                        title={t("common.changePassword")}
+                        description={t("settings.passwordDescription")}
+                        padding="md"
+                    >
+                        <div className="space-y-4">
+                            <div className="space-y-2">
+                                <Label htmlFor="currentPassword">{t("common.actualPassword")}</Label>
+                                <Input
+                                    id="currentPassword"
+                                    type="password"
+                                    value={currentPassword}
+                                    onChange={(e) => setCurrentPassword(e.target.value)}
+                                    autoComplete="current-password"
+                                />
+                            </div>
+                            <div className="grid gap-4 md:grid-cols-2">
                                 <div className="space-y-2">
-                                    <Label htmlFor="bio">{t("form.bio")}</Label>
+                                    <Label htmlFor="newPassword">{t("common.newPassword")}</Label>
                                     <Input
-                                        id="bio"
-                                        placeholder={t("settings.profile.bioPlaceholder")}
-                                        value={bio}
-                                        onChange={(e) => setBio(e.target.value)}
-                                        maxLength={1000}
+                                        id="newPassword"
+                                        type="password"
+                                        value={newPassword}
+                                        onChange={(e) => setNewPassword(e.target.value)}
+                                        autoComplete="new-password"
                                     />
                                 </div>
-
-                                <div className="flex justify-end gap-2">
-                                    <Button onClick={handleSaveProfile} disabled={isSavingProfile}>
-                                        {isSavingProfile && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                                        {t("common.save")}
-                                    </Button>
+                                <div className="space-y-2">
+                                    <Label htmlFor="confirmPassword">{t("common.confirmNewPassword")}</Label>
+                                    <Input
+                                        id="confirmPassword"
+                                        type="password"
+                                        value={confirmPassword}
+                                        onChange={(e) => setConfirmPassword(e.target.value)}
+                                        autoComplete="new-password"
+                                    />
                                 </div>
+                            </div>
+                            <div className="flex justify-end pt-2">
+                                <Button
+                                    onClick={handleChangePassword}
+                                    disabled={isChangingPassword}
+                                    variant="outline"
+                                    className="rounded-lg"
+                                >
+                                    {isChangingPassword && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                    <KeyRound className="mr-2 h-4 w-4" />
+                                    {t("common.changePassword")}
+                                </Button>
+                            </div>
+                        </div>
+                    </SectionCard>
+                </TabsContent>
 
-                                <Separator />
+                <TabsContent value="integrations" className="space-y-4 mt-0">
+                    <div className="grid gap-4">
+                        {/* Notion */}
+                        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+                            <div className="flex flex-wrap items-start justify-between gap-4">
+                                <div className="flex items-start gap-4">
+                                    <div className="grid h-12 w-12 shrink-0 place-items-center rounded-xl bg-slate-900 text-white dark:bg-white dark:text-slate-900">
+                                        <svg viewBox="0 0 24 24" className="h-6 w-6" fill="currentColor" aria-hidden>
+                                            <path d="M4.459 4.208c.746.606 1.026.56 2.428.466l13.215-.793c.28 0 .047-.28-.046-.326L17.86 1.968c-.42-.326-.98-.7-2.055-.607L3.01 2.295c-.466.046-.56.28-.374.466zm.793 3.08v13.904c0 .747.373 1.027 1.214.98l14.523-.84c.841-.046.935-.56.935-1.167V6.354c0-.606-.233-.933-.748-.887l-15.177.887c-.56.047-.747.327-.747.933zm14.337.745c.093.42 0 .84-.42.888l-.7.139v10.264c-.608.327-1.168.514-1.635.514-.748 0-.935-.234-1.495-.933l-4.577-7.186v6.952L12.21 19s0 .84-1.168.84l-3.222.186c-.093-.186 0-.653.327-.746l.84-.233V9.854L7.822 9.76c-.094-.42.14-1.026.793-1.073l3.456-.233 4.764 7.279v-6.44l-1.215-.139c-.093-.514.28-.887.747-.933zM1.936 1.035l13.31-.98c1.634-.14 2.055-.047 3.082.7l4.249 2.986c.7.513.934.653.934 1.213v16.378c0 1.026-.373 1.634-1.68 1.726l-15.458.934c-.98.047-1.448-.093-1.962-.747l-3.129-4.06c-.56-.747-.793-1.306-.793-1.96V2.667c0-.839.374-1.54 1.447-1.632z" />
+                                        </svg>
+                                    </div>
+                                    <div className="min-w-0">
+                                        <div className="flex items-center gap-2">
+                                            <h3 className="font-semibold text-slate-900 dark:text-slate-100">Notion</h3>
+                                            {notionConnected ? (
+                                                <StatusBadge variant="success" icon={Check}>{t("common.connected")}</StatusBadge>
+                                            ) : (
+                                                <StatusBadge variant="neutral" icon={X}>{t("common.disconnected")}</StatusBadge>
+                                            )}
+                                        </div>
+                                        <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                                            {t("settings.integrations.notion.description")}
+                                        </p>
+                                    </div>
+                                </div>
+                                {notionConnected && (
+                                    <Button
+                                        variant="outline"
+                                        onClick={handleDisconnectNotion}
+                                        disabled={isDisconnectingNotion}
+                                        className="rounded-lg"
+                                    >
+                                        {isDisconnectingNotion && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                        {t("settings.integrations.notion.disconnect")}
+                                    </Button>
+                                )}
+                            </div>
 
-                                <div className="space-y-4">
-                                    <h3 className="font-medium">{t("common.changePassword")}</h3>
-                                    <div className="space-y-2">
-                                        <Label htmlFor="currentPassword">{t("common.actualPassword")}</Label>
+                            {notionConnected ? (
+                                <div className="mt-4 grid gap-3 rounded-xl bg-slate-50 p-4 text-sm sm:grid-cols-2 dark:bg-slate-800/40">
+                                    <div>
+                                        <p className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                                            {t("settings.integrations.notion.parentPageLabel")}
+                                        </p>
+                                        <p className="mt-1 font-mono text-xs break-all text-slate-700 dark:text-slate-300">
+                                            {notionParentPageId || "—"}
+                                        </p>
+                                    </div>
+                                    <div>
+                                        <p className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                                            {t("settings.integrations.notion.lastSyncLabel")}
+                                        </p>
+                                        <p className="mt-1 text-slate-700 dark:text-slate-300">
+                                            {notionLastSync
+                                                ? new Date(notionLastSync).toLocaleString(locale === "en" ? "en-US" : "fr-FR", {
+                                                      dateStyle: "medium",
+                                                      timeStyle: "short",
+                                                  })
+                                                : t("settings.integrations.notion.neverSynced")}
+                                        </p>
+                                    </div>
+                                </div>
+                            ) : (
+                                <div className="mt-5 space-y-3">
+                                    <div className="space-y-1.5">
+                                        <Label htmlFor="notion-token">
+                                            {t("settings.integrations.notion.tokenLabel")}
+                                        </Label>
                                         <Input
-                                            id="currentPassword"
+                                            id="notion-token"
                                             type="password"
-                                            value={currentPassword}
-                                            onChange={(e) => setCurrentPassword(e.target.value)}
-                                            autoComplete="current-password"
+                                            autoComplete="off"
+                                            value={notionTokenInput}
+                                            onChange={(e) => setNotionTokenInput(e.target.value)}
+                                            placeholder={t("settings.integrations.notion.tokenPlaceholder")}
+                                            maxLength={500}
                                         />
+                                        <p className="text-xs text-slate-500 dark:text-slate-400">
+                                            {t("settings.integrations.notion.tokenHint")}
+                                        </p>
                                     </div>
-                                    <div className="grid gap-4 md:grid-cols-2">
-                                        <div className="space-y-2">
-                                            <Label htmlFor="newPassword">{t("common.newPassword")}</Label>
-                                            <Input
-                                                id="newPassword"
-                                                type="password"
-                                                value={newPassword}
-                                                onChange={(e) => setNewPassword(e.target.value)}
-                                                autoComplete="new-password"
-                                            />
-                                        </div>
-                                        <div className="space-y-2">
-                                            <Label htmlFor="confirmPassword">{t("common.confirmNewPassword")}</Label>
-                                            <Input
-                                                id="confirmPassword"
-                                                type="password"
-                                                value={confirmPassword}
-                                                onChange={(e) => setConfirmPassword(e.target.value)}
-                                                autoComplete="new-password"
-                                            />
-                                        </div>
+                                    <div className="space-y-1.5">
+                                        <Label htmlFor="notion-page">
+                                            {t("settings.integrations.notion.pageLabel")}
+                                        </Label>
+                                        <Input
+                                            id="notion-page"
+                                            value={notionPageInput}
+                                            onChange={(e) => setNotionPageInput(e.target.value)}
+                                            placeholder={t("settings.integrations.notion.pagePlaceholder")}
+                                            maxLength={500}
+                                        />
+                                        <p className="text-xs text-slate-500 dark:text-slate-400">
+                                            {t("settings.integrations.notion.pageHint")}
+                                        </p>
                                     </div>
-                                    <div className="flex justify-end">
-                                        <Button onClick={handleChangePassword} disabled={isChangingPassword} variant="outline">
-                                            {isChangingPassword && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                                            {t("common.changePassword")}
+                                    <div className="flex justify-end pt-1">
+                                        <Button
+                                            onClick={handleConnectNotion}
+                                            disabled={isSavingNotion}
+                                            className="rounded-lg bg-emerald-600 text-white hover:bg-emerald-700"
+                                        >
+                                            {isSavingNotion && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                            {t("common.connect")}
                                         </Button>
                                     </div>
                                 </div>
-                            </CardContent>
-                        </Card>
-                    </TabsContent>
+                            )}
+                        </div>
 
-                    <TabsContent value="integrations" className="space-y-6">
-                        <Card>
-                            <CardHeader>
-                                <CardTitle>{t("settings.integrations.title")}</CardTitle>
-                                <CardDescription>{t("settings.integrations.description")}</CardDescription>
-                            </CardHeader>
-                            <CardContent className="space-y-6">
-                                <div className="rounded-lg border dark:border-slate-800 p-4">
-                                    <div className="flex items-center justify-between gap-4 flex-wrap">
-                                        <div className="flex items-center gap-4">
-                                            <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-slate-100 dark:bg-slate-800">
-                                                <LinkIcon className="h-6 w-6 text-slate-700 dark:text-slate-300" />
-                                            </div>
-                                            <div>
-                                                <div className="flex items-center gap-2">
-                                                    <h3 className="font-medium">Notion</h3>
-                                                    {notionConnected ? (
-                                                        <Badge variant="default" className="gap-1">
-                                                            <Check className="h-3 w-3" />
-                                                            {t("common.connected")}
-                                                        </Badge>
-                                                    ) : (
-                                                        <Badge variant="secondary" className="gap-1">
-                                                            <X className="h-3 w-3" />
-                                                            {t("common.disconnected")}
-                                                        </Badge>
-                                                    )}
-                                                </div>
-                                                <p className="text-sm text-slate-600 dark:text-slate-400">
-                                                    {t("settings.integrations.notion.description")}
-                                                </p>
-                                            </div>
-                                        </div>
-                                        {notionConnected && (
-                                            <Button
-                                                variant="outline"
-                                                onClick={handleDisconnectNotion}
-                                                disabled={isDisconnectingNotion}
-                                            >
-                                                {isDisconnectingNotion && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                                                {t("settings.integrations.notion.disconnect")}
-                                            </Button>
-                                        )}
+                        {/* Google Calendar */}
+                        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+                            <div className="flex flex-wrap items-start justify-between gap-4">
+                                <div className="flex items-start gap-4">
+                                    <div className="grid h-12 w-12 shrink-0 place-items-center rounded-xl bg-slate-100 dark:bg-slate-800">
+                                        <svg className="h-7 w-7" viewBox="0 0 24 24" aria-hidden>
+                                            <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
+                                            <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+                                            <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+                                            <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+                                        </svg>
                                     </div>
-
-                                    {notionConnected ? (
-                                        <div className="mt-4 grid gap-2 text-sm text-slate-600 dark:text-slate-400 sm:grid-cols-2">
-                                            <div className="space-y-1">
-                                                <p className="text-xs uppercase tracking-wide opacity-70">
-                                                    {t("settings.integrations.notion.parentPageLabel")}
-                                                </p>
-                                                <p className="font-mono break-all text-slate-700 dark:text-slate-300">
-                                                    {notionParentPageId || "—"}
-                                                </p>
-                                            </div>
-                                            <div className="space-y-1">
-                                                <p className="text-xs uppercase tracking-wide opacity-70">
-                                                    {t("settings.integrations.notion.lastSyncLabel")}
-                                                </p>
-                                                <p className="text-slate-700 dark:text-slate-300">
-                                                    {notionLastSync
-                                                        ? new Date(notionLastSync).toLocaleString(locale === "en" ? "en-US" : "fr-FR", {
-                                                              dateStyle: "medium",
-                                                              timeStyle: "short",
-                                                          })
-                                                        : t("settings.integrations.notion.neverSynced")}
-                                                </p>
-                                            </div>
+                                    <div className="min-w-0">
+                                        <div className="flex items-center gap-2">
+                                            <h3 className="font-semibold text-slate-900 dark:text-slate-100">Google Calendar</h3>
+                                            {googleConnected ? (
+                                                <StatusBadge variant="success" icon={Check}>{t("common.connected")}</StatusBadge>
+                                            ) : (
+                                                <StatusBadge variant="neutral" icon={X}>{t("common.disconnected")}</StatusBadge>
+                                            )}
                                         </div>
-                                    ) : (
-                                        <div className="mt-4 space-y-3">
-                                            <div className="space-y-1.5">
-                                                <Label htmlFor="notion-token">
-                                                    {t("settings.integrations.notion.tokenLabel")}
-                                                </Label>
-                                                <Input
-                                                    id="notion-token"
-                                                    type="password"
-                                                    autoComplete="off"
-                                                    value={notionTokenInput}
-                                                    onChange={(e) => setNotionTokenInput(e.target.value)}
-                                                    placeholder={t("settings.integrations.notion.tokenPlaceholder")}
-                                                    maxLength={500}
-                                                />
-                                                <p className="text-xs text-slate-500 dark:text-slate-400">
-                                                    {t("settings.integrations.notion.tokenHint")}
-                                                </p>
-                                            </div>
-                                            <div className="space-y-1.5">
-                                                <Label htmlFor="notion-page">
-                                                    {t("settings.integrations.notion.pageLabel")}
-                                                </Label>
-                                                <Input
-                                                    id="notion-page"
-                                                    value={notionPageInput}
-                                                    onChange={(e) => setNotionPageInput(e.target.value)}
-                                                    placeholder={t("settings.integrations.notion.pagePlaceholder")}
-                                                    maxLength={500}
-                                                />
-                                                <p className="text-xs text-slate-500 dark:text-slate-400">
-                                                    {t("settings.integrations.notion.pageHint")}
-                                                </p>
-                                            </div>
-                                            <div className="flex justify-end">
-                                                <Button onClick={handleConnectNotion} disabled={isSavingNotion}>
-                                                    {isSavingNotion && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                                                    {t("common.connect")}
-                                                </Button>
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-
-                                <Separator />
-
-                                <div className="rounded-lg border dark:border-slate-800 p-4">
-                                    <div className="flex items-center justify-between gap-4 flex-wrap">
-                                        <div className="flex items-center gap-4">
-                                            <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-slate-100 dark:bg-slate-800">
-                                                <svg className="h-6 w-6" viewBox="0 0 24 24">
-                                                    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
-                                                    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
-                                                    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
-                                                    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
-                                                </svg>
-                                            </div>
-                                            <div>
-                                                <div className="flex items-center gap-2">
-                                                    <h3 className="font-medium">Google Calendar</h3>
-                                                    {googleConnected ? (
-                                                        <Badge variant="default" className="gap-1">
-                                                            <Check className="h-3 w-3" />
-                                                            {t("common.connected")}
-                                                        </Badge>
-                                                    ) : (
-                                                        <Badge variant="secondary" className="gap-1">
-                                                            <X className="h-3 w-3" />
-                                                            {t("common.disconnected")}
-                                                        </Badge>
-                                                    )}
-                                                </div>
-                                                <p className="text-sm text-slate-600 dark:text-slate-400">
-                                                    {t("settings.integrations.google.description")}
-                                                </p>
-                                            </div>
-                                        </div>
-                                        {googleConnected ? (
-                                            <Button
-                                                variant="outline"
-                                                onClick={handleDisconnectGoogle}
-                                                disabled={isDisconnectingGoogle}
-                                            >
-                                                {isDisconnectingGoogle && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                                                {t("settings.integrations.google.disconnect")}
-                                            </Button>
-                                        ) : (
-                                            <Button variant="outline" onClick={handleConnectGoogleCalendar}>
-                                                {t("common.connect")}
-                                            </Button>
-                                        )}
-                                    </div>
-
-                                    {googleConnected && (
-                                        <div className="mt-4 grid gap-2 text-sm text-slate-600 dark:text-slate-400 sm:grid-cols-2">
-                                            <div className="space-y-1">
-                                                <p className="text-xs uppercase tracking-wide opacity-70">
-                                                    {t("settings.integrations.google.scopesLabel")}
-                                                </p>
-                                                <p className="text-xs font-mono break-all text-slate-700 dark:text-slate-300">
-                                                    {googleScopes || "—"}
-                                                </p>
-                                            </div>
-                                            <div className="space-y-1">
-                                                <p className="text-xs uppercase tracking-wide opacity-70">
-                                                    {t("settings.integrations.google.lastSyncLabel")}
-                                                </p>
-                                                <p className="text-slate-700 dark:text-slate-300">
-                                                    {googleLastSync
-                                                        ? new Date(googleLastSync).toLocaleString(locale === "en" ? "en-US" : "fr-FR", {
-                                                              dateStyle: "medium",
-                                                              timeStyle: "short",
-                                                          })
-                                                        : t("settings.integrations.google.neverSynced")}
-                                                </p>
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-                            </CardContent>
-                        </Card>
-                    </TabsContent>
-
-                    <TabsContent value="notifications" className="space-y-6">
-                        <Card>
-                            <CardHeader>
-                                <CardTitle>{t("settings.notifications.title")}</CardTitle>
-                                <CardDescription>{t("settings.notifications.description")}</CardDescription>
-                            </CardHeader>
-                            <CardContent className="space-y-6">
-                                <div className="flex items-center justify-between">
-                                    <div className="space-y-0.5">
-                                        <Label>{t("settings.notifications.email")}</Label>
-                                        <p className="text-sm text-slate-500 dark:text-slate-400">{t("settings.notifications.emailHint")}</p>
-                                    </div>
-                                    <Switch checked={notifications.email} onCheckedChange={setNotif("email")} />
-                                </div>
-
-                                <Separator />
-
-                                <div className="flex items-center justify-between">
-                                    <div className="space-y-0.5">
-                                        <Label>{t("settings.notifications.weekly")}</Label>
-                                        <p className="text-sm text-slate-500 dark:text-slate-400">{t("settings.notifications.weeklyHint")}</p>
-                                    </div>
-                                    <Switch checked={notifications.weekly} onCheckedChange={setNotif("weekly")} />
-                                </div>
-
-                                <Separator />
-
-                                <div className="flex items-center justify-between">
-                                    <div className="space-y-0.5">
-                                        <Label>{t("settings.notifications.ai")}</Label>
-                                        <p className="text-sm text-slate-500 dark:text-slate-400">{t("settings.notifications.aiHint")}</p>
-                                    </div>
-                                    <Switch checked={notifications.ai} onCheckedChange={setNotif("ai")} />
-                                </div>
-
-                                <Separator />
-
-                                <div className="space-y-3">
-                                    <Label>{t("settings.notifications.types")}</Label>
-                                    <div className="space-y-3">
-                                        <div className="flex items-center justify-between">
-                                            <span className="text-sm">{t("settings.notifications.comments")}</span>
-                                            <Switch checked={notifications.comments} onCheckedChange={setNotif("comments")} />
-                                        </div>
-                                        <div className="flex items-center justify-between">
-                                            <span className="text-sm">{t("settings.notifications.updates")}</span>
-                                            <Switch checked={notifications.updates} onCheckedChange={setNotif("updates")} />
-                                        </div>
-                                        <div className="flex items-center justify-between">
-                                            <span className="text-sm">{t("settings.notifications.tips")}</span>
-                                            <Switch checked={notifications.tips} onCheckedChange={setNotif("tips")} />
-                                        </div>
+                                        <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                                            {t("settings.integrations.google.description")}
+                                        </p>
                                     </div>
                                 </div>
-
-                                <div className="flex justify-end">
-                                    <Button onClick={handleSaveNotifs} disabled={isSavingNotifs}>
-                                        {isSavingNotifs && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                                        {t("settings.notifications.savePrefs")}
+                                {googleConnected ? (
+                                    <Button
+                                        variant="outline"
+                                        onClick={handleDisconnectGoogle}
+                                        disabled={isDisconnectingGoogle}
+                                        className="rounded-lg"
+                                    >
+                                        {isDisconnectingGoogle && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                        {t("settings.integrations.google.disconnect")}
                                     </Button>
+                                ) : (
+                                    <Button
+                                        onClick={handleConnectGoogleCalendar}
+                                        className="rounded-lg bg-emerald-600 text-white hover:bg-emerald-700"
+                                    >
+                                        {t("common.connect")}
+                                    </Button>
+                                )}
+                            </div>
+
+                            {googleConnected && (
+                                <div className="mt-4 grid gap-3 rounded-xl bg-slate-50 p-4 text-sm sm:grid-cols-2 dark:bg-slate-800/40">
+                                    <div>
+                                        <p className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                                            {t("settings.integrations.google.scopesLabel")}
+                                        </p>
+                                        <p className="mt-1 font-mono text-xs break-all text-slate-700 dark:text-slate-300">
+                                            {googleScopes || "—"}
+                                        </p>
+                                    </div>
+                                    <div>
+                                        <p className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                                            {t("settings.integrations.google.lastSyncLabel")}
+                                        </p>
+                                        <p className="mt-1 text-slate-700 dark:text-slate-300">
+                                            {googleLastSync
+                                                ? new Date(googleLastSync).toLocaleString(locale === "en" ? "en-US" : "fr-FR", {
+                                                      dateStyle: "medium",
+                                                      timeStyle: "short",
+                                                  })
+                                                : t("settings.integrations.google.neverSynced")}
+                                        </p>
+                                    </div>
                                 </div>
-                            </CardContent>
-                        </Card>
-                    </TabsContent>
+                            )}
+                        </div>
+                    </div>
+                </TabsContent>
 
-                    <TabsContent value="security" className="space-y-6">
-                        <SecurityIpList />
-                    </TabsContent>
+                <TabsContent value="notifications" className="space-y-6 mt-0">
+                    <SectionCard
+                        title={t("settings.notifications.title")}
+                        description={t("settings.notifications.description")}
+                        padding="md"
+                    >
+                        <div className="space-y-1">
+                            <div className="flex items-center justify-between gap-4 py-3">
+                                <div className="space-y-0.5 min-w-0">
+                                    <Label>{t("settings.notifications.email")}</Label>
+                                    <p className="text-sm text-slate-500 dark:text-slate-400">{t("settings.notifications.emailHint")}</p>
+                                </div>
+                                <Switch checked={notifications.email} onCheckedChange={setNotif("email")} />
+                            </div>
+                            <Separator />
+                            <div className="flex items-center justify-between gap-4 py-3">
+                                <div className="space-y-0.5 min-w-0">
+                                    <Label>{t("settings.notifications.weekly")}</Label>
+                                    <p className="text-sm text-slate-500 dark:text-slate-400">{t("settings.notifications.weeklyHint")}</p>
+                                </div>
+                                <Switch checked={notifications.weekly} onCheckedChange={setNotif("weekly")} />
+                            </div>
+                            <Separator />
+                            <div className="flex items-center justify-between gap-4 py-3">
+                                <div className="space-y-0.5 min-w-0">
+                                    <Label>{t("settings.notifications.ai")}</Label>
+                                    <p className="text-sm text-slate-500 dark:text-slate-400">{t("settings.notifications.aiHint")}</p>
+                                </div>
+                                <Switch checked={notifications.ai} onCheckedChange={setNotif("ai")} />
+                            </div>
+                        </div>
 
-                    <TabsContent value="preferences" className="space-y-6">
-                        <Card>
-                            <CardHeader>
-                                <CardTitle>{t("settings.preferences.title")}</CardTitle>
-                                <CardDescription>{t("settings.preferences.description")}</CardDescription>
-                            </CardHeader>
-                            <CardContent className="space-y-6">
+                        <div className="mt-6 space-y-3 border-t border-slate-100 pt-5 dark:border-slate-800">
+                            <Label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                                {t("settings.notifications.types")}
+                            </Label>
+                            <div className="space-y-1">
+                                <div className="flex items-center justify-between py-2">
+                                    <span className="text-sm text-slate-700 dark:text-slate-300">{t("settings.notifications.comments")}</span>
+                                    <Switch checked={notifications.comments} onCheckedChange={setNotif("comments")} />
+                                </div>
+                                <div className="flex items-center justify-between py-2">
+                                    <span className="text-sm text-slate-700 dark:text-slate-300">{t("settings.notifications.updates")}</span>
+                                    <Switch checked={notifications.updates} onCheckedChange={setNotif("updates")} />
+                                </div>
+                                <div className="flex items-center justify-between py-2">
+                                    <span className="text-sm text-slate-700 dark:text-slate-300">{t("settings.notifications.tips")}</span>
+                                    <Switch checked={notifications.tips} onCheckedChange={setNotif("tips")} />
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="flex justify-end pt-4">
+                            <Button
+                                onClick={handleSaveNotifs}
+                                disabled={isSavingNotifs}
+                                className="rounded-lg bg-emerald-600 text-white hover:bg-emerald-700"
+                            >
+                                {isSavingNotifs && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                {t("settings.notifications.savePrefs")}
+                            </Button>
+                        </div>
+                    </SectionCard>
+                </TabsContent>
+
+                <TabsContent value="security" className="space-y-6 mt-0">
+                    <SecurityIpList />
+                </TabsContent>
+
+                <TabsContent value="preferences" className="space-y-6 mt-0">
+                    <SectionCard
+                        title={t("settings.preferences.title")}
+                        description={t("settings.preferences.description")}
+                        padding="md"
+                    >
+                        <div className="space-y-6">
+                            <div className="grid gap-4 md:grid-cols-2">
                                 <div className="space-y-2">
                                     <Label htmlFor="language">{t("settings.preferences.language")}</Label>
                                     <Select value={locale} onValueChange={changeLocale}>
@@ -860,71 +867,81 @@ const Settings = () => {
                                         </SelectContent>
                                     </Select>
                                 </div>
+                            </div>
 
-                                <Separator />
-
-                                <div className="space-y-3">
-                                    <Label className="flex items-center gap-2">
-                                        <Sparkles className="h-4 w-4" />
-                                        {t("settings.preferences.aiSettings")}
-                                    </Label>
-                                    <div className="space-y-2">
-                                        <Label htmlFor="defaultTone" className="text-sm">
-                                            {t("settings.preferences.defaultTone")}
-                                        </Label>
-                                        <Select value={defaultTone || ""} onValueChange={setDefaultTone}>
-                                            <SelectTrigger id="defaultTone">
-                                                <SelectValue placeholder={t("editor.tonePlaceholder")} />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                <SelectItem value="professional">{t("editor.tones.professional")}</SelectItem>
-                                                <SelectItem value="casual">{t("editor.tones.casual")}</SelectItem>
-                                                <SelectItem value="friendly">{t("editor.tones.friendly")}</SelectItem>
-                                                <SelectItem value="formal">{t("editor.tones.formal")}</SelectItem>
-                                                <SelectItem value="enthusiastic">{t("editor.tones.enthusiastic")}</SelectItem>
-                                            </SelectContent>
-                                        </Select>
-                                    </div>
-                                    <div className="space-y-2">
-                                        <Label htmlFor="defaultWords" className="text-sm">
-                                            {t("settings.preferences.defaultWords")}
-                                        </Label>
-                                        <Input
-                                            id="defaultWords"
-                                            type="number"
-                                            min={100}
-                                            max={5000}
-                                            value={defaultWords}
-                                            onChange={(e) => setDefaultWords(Number(e.target.value) || 0)}
-                                        />
+                            <div className="flex items-center justify-between gap-4 rounded-xl border border-slate-200 bg-slate-50/50 px-4 py-3 dark:border-slate-800 dark:bg-slate-800/30">
+                                <div className="flex items-center gap-3 min-w-0">
+                                    <span className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-slate-900 text-white dark:bg-white dark:text-slate-900">
+                                        <Moon className="h-4 w-4" />
+                                    </span>
+                                    <div className="min-w-0">
+                                        <Label className="cursor-pointer">{t("settings.preferences.darkMode")}</Label>
+                                        <p className="text-xs text-slate-500 dark:text-slate-400">{t("settings.preferences.darkModeHint")}</p>
                                     </div>
                                 </div>
+                                <Switch
+                                    checked={isDark}
+                                    onCheckedChange={(checked) => setTheme(checked ? "dark" : "light")}
+                                />
+                            </div>
+                        </div>
+                    </SectionCard>
 
-                                <Separator />
-
-                                <div className="flex items-center justify-between">
-                                    <div className="space-y-0.5">
-                                        <Label>{t("settings.preferences.darkMode")}</Label>
-                                        <p className="text-sm text-slate-500 dark:text-slate-400">{t("settings.preferences.darkModeHint")}</p>
-                                    </div>
-                                    <Switch
-                                        checked={isDark}
-                                        onCheckedChange={(checked) => setTheme(checked ? "dark" : "light")}
+                    <SectionCard
+                        title={t("settings.preferences.aiSettings")}
+                        description={t("settings.preferences.aiDescription")}
+                        padding="md"
+                    >
+                        <div className="space-y-4">
+                            <div className="grid gap-4 md:grid-cols-2">
+                                <div className="space-y-2">
+                                    <Label htmlFor="defaultTone">
+                                        {t("settings.preferences.defaultTone")}
+                                    </Label>
+                                    <Select value={defaultTone || ""} onValueChange={setDefaultTone}>
+                                        <SelectTrigger id="defaultTone">
+                                            <SelectValue placeholder={t("editor.tonePlaceholder")} />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="professional">{t("editor.tones.professional")}</SelectItem>
+                                            <SelectItem value="casual">{t("editor.tones.casual")}</SelectItem>
+                                            <SelectItem value="friendly">{t("editor.tones.friendly")}</SelectItem>
+                                            <SelectItem value="formal">{t("editor.tones.formal")}</SelectItem>
+                                            <SelectItem value="enthusiastic">{t("editor.tones.enthusiastic")}</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="defaultWords">
+                                        {t("settings.preferences.defaultWords")}
+                                    </Label>
+                                    <Input
+                                        id="defaultWords"
+                                        type="number"
+                                        min={100}
+                                        max={5000}
+                                        value={defaultWords}
+                                        onChange={(e) => setDefaultWords(Number(e.target.value) || 0)}
                                     />
                                 </div>
+                            </div>
 
-                                <div className="flex justify-end">
-                                    <Button onClick={handleSavePrefs} disabled={isSavingPrefs}>
-                                        {isSavingPrefs && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                                        {t("settings.notifications.savePrefs")}
-                                    </Button>
-                                </div>
-                            </CardContent>
-                        </Card>
-                    </TabsContent>
-                </Tabs>
-            </div>
-        </div>
+                            <div className="flex justify-end pt-2">
+                                <Button
+                                    onClick={handleSavePrefs}
+                                    disabled={isSavingPrefs}
+                                    className="rounded-lg bg-emerald-600 text-white hover:bg-emerald-700"
+                                >
+                                    {isSavingPrefs && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                    <Sparkles className="mr-2 h-4 w-4" />
+                                    {t("common.save")}
+                                </Button>
+                            </div>
+                        </div>
+                    </SectionCard>
+                </TabsContent>
+            </Tabs>
+        </PageShell>
     );
 };
 

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -37,15 +37,17 @@ export const Sidebar = ({ onNavigate }) => {
 
   return (
     <div className="flex h-full flex-col bg-slate-900 text-white overflow-y-auto">
-      <div className="hidden md:flex h-16 items-center gap-2 border-b border-slate-700 px-6">
-        <PenTool className="h-6 w-6 text-emerald-400" />
-        <span className="text-lg">{t("brand")}</span>
+      <div className="hidden md:flex h-16 items-center gap-2.5 border-b border-slate-800 px-6">
+        <span className="grid h-9 w-9 place-items-center rounded-xl bg-emerald-500/15 text-emerald-400">
+          <PenTool className="h-4.5 w-4.5" />
+        </span>
+        <span className="text-base font-semibold tracking-tight">{t("brand")}</span>
       </div>
 
-      <nav className="flex-1 space-y-1 px-3 py-4">
+      <nav className="flex-1 space-y-0.5 px-3 py-5">
         {navigation.map((item) => {
           const Icon = item.icon;
-          const isActive = pathname === item.href;
+          const isActive = pathname === item.href || (item.href !== "/dashboard" && pathname?.startsWith(item.href + "/"));
 
           return (
             <Link
@@ -53,26 +55,32 @@ export const Sidebar = ({ onNavigate }) => {
               href={item.href}
               onClick={() => handleNavClick(item.href)}
               className={cn(
-                "flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors",
+                "group relative flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors",
                 isActive
-                  ? "bg-emerald-500 text-white"
-                  : "text-slate-300 hover:bg-slate-800 hover:text-white"
+                  ? "bg-slate-800/80 text-white"
+                  : "text-slate-400 hover:bg-slate-800/50 hover:text-white"
               )}
             >
-              <Icon className="h-5 w-5" />
-              <span>{item.name}</span>
+              {isActive && (
+                <span
+                  aria-hidden
+                  className="absolute left-0 top-1/2 h-6 w-1 -translate-y-1/2 rounded-r-full bg-emerald-500"
+                />
+              )}
+              <Icon className={cn("h-4.5 w-4.5", isActive ? "text-emerald-400" : "text-slate-400 group-hover:text-slate-200")} />
+              <span className="font-medium">{item.name}</span>
             </Link>
           );
         })}
       </nav>
 
-      <div className="border-t border-slate-700 p-4">
-        <button 
+      <div className="border-t border-slate-800 p-3">
+        <button
           onClick={handleLogout}
-          className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-slate-300 transition-colors hover:bg-slate-800 hover:text-white"
+          className="group flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm text-slate-400 transition-colors hover:bg-slate-800/50 hover:text-white"
         >
-          <LogOut className="h-5 w-5" />
-          <span>{ t('nav.logout') }</span>
+          <LogOut className="h-4.5 w-4.5 group-hover:text-rose-400" />
+          <span className="font-medium">{ t('nav.logout') }</span>
         </button>
       </div>
     </div>

--- a/frontend/src/components/editor/ArticleEditor.jsx
+++ b/frontend/src/components/editor/ArticleEditor.jsx
@@ -525,7 +525,7 @@ export const ArticleEditor = ({ initialArticle = null, articleId = null }) => {
     const statusVariantKey = status === "published" ? "published" : status === "review" ? "review" : status === "archived" ? "archived" : "draft";
 
     return (
-        <div className="flex h-screen overflow-hidden bg-slate-50 dark:bg-slate-950">
+        <div className="flex h-full overflow-hidden bg-slate-50 dark:bg-slate-950">
             <div className="flex flex-1 flex-col overflow-hidden">
                 <div className="border-b border-slate-200 bg-white/90 backdrop-blur-sm px-4 py-3 md:px-6 md:py-4 dark:border-slate-800 dark:bg-slate-900/90">
                     <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">

--- a/frontend/src/components/editor/ArticleEditor.jsx
+++ b/frontend/src/components/editor/ArticleEditor.jsx
@@ -22,6 +22,7 @@ import { toast } from "sonner";
 import { Badge } from "@/components/Badge";
 import { Button } from "@/components/Button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/Card";
+import { StatusBadge } from "@/components/ui-kit";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/Dialog";
 import { Input } from "@/components/Input";
 import { Label } from "@/components/Label";
@@ -521,18 +522,31 @@ export const ArticleEditor = ({ initialArticle = null, articleId = null }) => {
     const isAnyAiActionRunning =
         activeAction !== null || isGenerating || isRewriting || isLoadingSuggestions;
 
+    const statusVariantKey = status === "published" ? "published" : status === "review" ? "review" : status === "archived" ? "archived" : "draft";
+
     return (
         <div className="flex h-screen overflow-hidden bg-slate-50 dark:bg-slate-950">
             <div className="flex flex-1 flex-col overflow-hidden">
-                <div className="border-b dark:border-slate-800 bg-white dark:bg-slate-900 px-6 py-4">
-                    <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-4">
-                            <h1 className="text-2xl">{t("editor.title")}</h1>
-                            <Badge variant="secondary">{t("editor.wordCount", { count: wordCount })}</Badge>
-                            <Badge variant="outline">{statusLabel}</Badge>
+                <div className="border-b border-slate-200 bg-white/90 backdrop-blur-sm px-4 py-3 md:px-6 md:py-4 dark:border-slate-800 dark:bg-slate-900/90">
+                    <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                        <div className="flex flex-wrap items-center gap-3">
+                            <h1 className="text-xl md:text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+                                {t("editor.title")}
+                            </h1>
+                            <div className="flex items-center gap-2">
+                                <StatusBadge variant={statusVariantKey}>{statusLabel}</StatusBadge>
+                                <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                                    {t("editor.wordCount", { count: wordCount })}
+                                </span>
+                            </div>
                         </div>
-                        <div className="flex items-center gap-2">
-                            <Button variant="outline" onClick={handleSave} disabled={isSaving || isPublishing}>
+                        <div className="flex flex-wrap items-center gap-2">
+                            <Button
+                                variant="outline"
+                                onClick={handleSave}
+                                disabled={isSaving || isPublishing}
+                                className="rounded-lg"
+                            >
                                 {isSaving ? (
                                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                                 ) : (
@@ -540,11 +554,15 @@ export const ArticleEditor = ({ initialArticle = null, articleId = null }) => {
                                 )}
                                 {t("editor.save")}
                             </Button>
-                            <Button variant="outline" disabled>
+                            <Button variant="outline" disabled className="rounded-lg">
                                 <Eye className="mr-2 h-4 w-4" />
                                 {t("editor.preview")}
                             </Button>
-                            <Button onClick={handlePublish} disabled={isSaving || isPublishing}>
+                            <Button
+                                onClick={handlePublish}
+                                disabled={isSaving || isPublishing}
+                                className="rounded-lg bg-emerald-600 text-white hover:bg-emerald-700"
+                            >
                                 {isPublishing ? (
                                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                                 ) : (

--- a/frontend/src/components/layouts/LayoutWrapper.jsx
+++ b/frontend/src/components/layouts/LayoutWrapper.jsx
@@ -8,10 +8,13 @@ import { useTranslation } from "@/hooks/useI18n";
 
 const SIDEBAR_ROUTES = ["/dashboard", "/history", "/ideas", "/settings", "/editor"];
 
+const matchesSidebarRoute = (pathname) =>
+    SIDEBAR_ROUTES.some((route) => pathname === route || pathname.startsWith(route + "/"));
+
 export const LayoutWrapper = ({ children }) => {
     const pathname = usePathname();
     const { t } = useTranslation();
-    const showSidebar = SIDEBAR_ROUTES.includes(pathname);
+    const showSidebar = matchesSidebarRoute(pathname);
     const [sidebarOpen, setSidebarOpen] = useState(false);
 
     const toggleSidebar = () => setSidebarOpen(!sidebarOpen);

--- a/frontend/src/components/ui-kit/EmptyState.jsx
+++ b/frontend/src/components/ui-kit/EmptyState.jsx
@@ -1,0 +1,29 @@
+"use client";
+
+/**
+ * Empty state cohérent (illustration optionnelle, titre, description, CTA).
+ * Remplace les `border border-dashed py-12` ad-hoc disséminés.
+ */
+export const EmptyState = ({ icon: Icon, title, description, action, footer, className = "" }) => (
+    <div
+        className={`flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-200 bg-slate-50/50 px-6 py-12 text-center dark:border-slate-800 dark:bg-slate-900/40 ${className}`}
+    >
+        {Icon && (
+            <span className="mb-4 grid h-12 w-12 place-items-center rounded-2xl bg-white text-slate-400 shadow-sm dark:bg-slate-800 dark:text-slate-500">
+                <Icon className="h-5 w-5" />
+            </span>
+        )}
+        {title && (
+            <p className="text-base font-medium text-slate-900 dark:text-slate-100">{title}</p>
+        )}
+        {description && (
+            <p className="mt-1 max-w-md text-sm text-slate-500 dark:text-slate-400">
+                {description}
+            </p>
+        )}
+        {action && <div className="mt-5">{action}</div>}
+        {footer && <div className="mt-3 text-xs text-slate-500 dark:text-slate-400">{footer}</div>}
+    </div>
+);
+
+export default EmptyState;

--- a/frontend/src/components/ui-kit/PageHeader.jsx
+++ b/frontend/src/components/ui-kit/PageHeader.jsx
@@ -1,0 +1,43 @@
+"use client";
+
+/**
+ * Header de page : eyebrow optionnel + titre + description + actions.
+ * Pattern repris de AdminPageHeader mais sans breadcrumb (les pages user
+ * sont au premier niveau).
+ *
+ * @param {object} props
+ * @param {string} [props.eyebrow] - Petit label uppercase au-dessus du titre.
+ * @param {string} props.title
+ * @param {string} [props.description]
+ * @param {React.ReactNode} [props.actions] - Boutons à droite (CTAs primaires/secondaires).
+ * @param {React.ReactNode} [props.icon] - Icône décorative à gauche du titre (optionnel).
+ */
+export const PageHeader = ({ eyebrow, title, description, actions, icon }) => (
+    <header className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0 flex items-start gap-3">
+            {icon && (
+                <span className="hidden md:grid h-11 w-11 shrink-0 place-items-center rounded-2xl bg-emerald-100 text-emerald-600 dark:bg-emerald-950/40 dark:text-emerald-400">
+                    {icon}
+                </span>
+            )}
+            <div className="min-w-0">
+                {eyebrow && (
+                    <p className="text-xs font-medium uppercase tracking-wide text-emerald-600 dark:text-emerald-400">
+                        {eyebrow}
+                    </p>
+                )}
+                <h1 className="text-2xl md:text-3xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+                    {title}
+                </h1>
+                {description && (
+                    <p className="mt-1 text-sm text-slate-600 dark:text-slate-400 max-w-2xl">
+                        {description}
+                    </p>
+                )}
+            </div>
+        </div>
+        {actions && <div className="flex flex-wrap items-center gap-2 shrink-0">{actions}</div>}
+    </header>
+);
+
+export default PageHeader;

--- a/frontend/src/components/ui-kit/PageShell.jsx
+++ b/frontend/src/components/ui-kit/PageShell.jsx
@@ -1,0 +1,16 @@
+"use client";
+
+/**
+ * Wrapper de page user (dashboard, history, ideas, settings, editor).
+ * Garantit fond + padding + container cohérents sur toutes les pages.
+ * Permet aux pages de ne s'occuper que de leur contenu structuré.
+ */
+export const PageShell = ({ children, className = "" }) => (
+    <div className={`flex-1 overflow-auto bg-slate-50 dark:bg-slate-950 ${className}`}>
+        <div className="mx-auto w-full max-w-7xl px-4 py-6 md:px-6 md:py-10">
+            <div className="space-y-6 md:space-y-8">{children}</div>
+        </div>
+    </div>
+);
+
+export default PageShell;

--- a/frontend/src/components/ui-kit/SectionCard.jsx
+++ b/frontend/src/components/ui-kit/SectionCard.jsx
@@ -1,0 +1,57 @@
+"use client";
+
+/**
+ * Section card générique avec header (titre + description + actions) et body.
+ * Equivalent du Panel admin, adapté aux pages user (padding plus généreux).
+ *
+ * @param {object} props
+ * @param {string} [props.title]
+ * @param {string} [props.description]
+ * @param {React.ReactNode} [props.actions]
+ * @param {string} [props.padding="md"] - "none" | "sm" | "md" | "lg"
+ */
+export const SectionCard = ({
+    title,
+    description,
+    actions,
+    padding = "md",
+    className = "",
+    children,
+}) => {
+    const padMap = {
+        none: "",
+        sm: "p-4",
+        md: "p-5 md:p-6",
+        lg: "p-6 md:p-8",
+    };
+    const bodyPad = padMap[padding] ?? padMap.md;
+
+    return (
+        <section
+            className={`rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900 ${className}`}
+        >
+            {(title || description || actions) && (
+                <div className="flex flex-col gap-3 border-b border-slate-100 px-5 py-4 dark:border-slate-800 md:flex-row md:items-center md:justify-between md:px-6">
+                    <div className="min-w-0">
+                        {title && (
+                            <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+                                {title}
+                            </h3>
+                        )}
+                        {description && (
+                            <p className="mt-0.5 text-sm text-slate-500 dark:text-slate-400">
+                                {description}
+                            </p>
+                        )}
+                    </div>
+                    {actions && (
+                        <div className="flex flex-wrap items-center gap-2 shrink-0">{actions}</div>
+                    )}
+                </div>
+            )}
+            <div className={bodyPad}>{children}</div>
+        </section>
+    );
+};
+
+export default SectionCard;

--- a/frontend/src/components/ui-kit/StatCard.jsx
+++ b/frontend/src/components/ui-kit/StatCard.jsx
@@ -1,0 +1,66 @@
+"use client";
+
+const TONE_MAP = {
+    emerald: {
+        iconBg: "bg-emerald-100 dark:bg-emerald-950/40",
+        iconColor: "text-emerald-600 dark:text-emerald-400",
+    },
+    blue: {
+        iconBg: "bg-blue-100 dark:bg-blue-950/40",
+        iconColor: "text-blue-600 dark:text-blue-400",
+    },
+    amber: {
+        iconBg: "bg-amber-100 dark:bg-amber-950/40",
+        iconColor: "text-amber-600 dark:text-amber-400",
+    },
+    violet: {
+        iconBg: "bg-violet-100 dark:bg-violet-950/40",
+        iconColor: "text-violet-600 dark:text-violet-400",
+    },
+    rose: {
+        iconBg: "bg-rose-100 dark:bg-rose-950/40",
+        iconColor: "text-rose-600 dark:text-rose-400",
+    },
+    slate: {
+        iconBg: "bg-slate-100 dark:bg-slate-800",
+        iconColor: "text-slate-600 dark:text-slate-300",
+    },
+};
+
+/**
+ * KPI card unifiée. Reprend le pattern admin : label uppercase à gauche,
+ * badge icône coloré à droite, valeur en gras dessous, hint optionnel.
+ *
+ * @param {object} props
+ * @param {string} props.label
+ * @param {React.ReactNode} props.value
+ * @param {React.ComponentType} [props.icon]
+ * @param {keyof typeof TONE_MAP} [props.tone="emerald"]
+ * @param {string} [props.hint]
+ */
+export const StatCard = ({ label, value, icon: Icon, tone = "emerald", hint }) => {
+    const palette = TONE_MAP[tone] || TONE_MAP.emerald;
+
+    return (
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900">
+            <div className="flex items-center justify-between gap-3">
+                <span className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    {label}
+                </span>
+                {Icon && (
+                    <span className={`grid h-9 w-9 shrink-0 place-items-center rounded-xl ${palette.iconBg}`}>
+                        <Icon className={`h-4 w-4 ${palette.iconColor}`} />
+                    </span>
+                )}
+            </div>
+            <p className="mt-3 text-2xl md:text-3xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+                {value}
+            </p>
+            {hint && (
+                <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{hint}</p>
+            )}
+        </div>
+    );
+};
+
+export default StatCard;

--- a/frontend/src/components/ui-kit/StatusBadge.jsx
+++ b/frontend/src/components/ui-kit/StatusBadge.jsx
@@ -1,0 +1,46 @@
+"use client";
+
+const VARIANTS = {
+    // Statuts d'articles
+    draft: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+    review: "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400",
+    published: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400",
+    archived: "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400",
+
+    // Sémantique générique
+    success: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400",
+    warning: "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400",
+    danger: "bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-400",
+    info: "bg-blue-100 text-blue-700 dark:bg-blue-950/40 dark:text-blue-400",
+    neutral: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+
+    // Difficulté (ideas)
+    easy: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400",
+    medium: "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400",
+    hard: "bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-400",
+
+    // Accent brand
+    accent: "bg-violet-100 text-violet-700 dark:bg-violet-950/40 dark:text-violet-300",
+};
+
+/**
+ * Badge / pill de statut unifié. Préférer cette primitive aux classes inline
+ * pour garder cohérence light/dark.
+ *
+ * @param {object} props
+ * @param {keyof typeof VARIANTS} props.variant
+ * @param {React.ReactNode} [props.icon]
+ */
+export const StatusBadge = ({ variant = "neutral", icon: Icon, children, className = "" }) => {
+    const cls = VARIANTS[variant] || VARIANTS.neutral;
+    return (
+        <span
+            className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${cls} ${className}`}
+        >
+            {Icon && <Icon className="h-3 w-3" />}
+            {children}
+        </span>
+    );
+};
+
+export default StatusBadge;

--- a/frontend/src/components/ui-kit/index.js
+++ b/frontend/src/components/ui-kit/index.js
@@ -1,0 +1,6 @@
+export { PageShell } from "./PageShell";
+export { PageHeader } from "./PageHeader";
+export { StatCard } from "./StatCard";
+export { SectionCard } from "./SectionCard";
+export { EmptyState } from "./EmptyState";
+export { StatusBadge } from "./StatusBadge";

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -262,7 +262,10 @@
   },
   "dashboard": {
     "title": "Welcome to SEO Content AI",
-    "subtitle": "Here's an overview of your activity",
+    "eyebrow": "Dashboard",
+    "greeting": "Hello, {name}",
+    "greetingGeneric": "Hello",
+    "subtitle": "Here's an overview of your content creation activity.",
     "loading": "Loading your dashboard...",
     "loadError": "Could not load your dashboard.",
     "stats": {
@@ -287,7 +290,8 @@
       "title": "Recent articles",
       "description": "Your latest updated content",
       "seoScoreLabel": "SEO score",
-      "empty": "No articles yet. Start by generating an idea or writing in the editor.",
+      "emptyTitle": "No articles yet",
+      "empty": "Start by generating an idea or writing your first article in the editor.",
       "status": {
         "published": "Published",
         "draft": "Draft",
@@ -305,7 +309,10 @@
   },
   "history": {
     "title": "Publication history",
-    "subtitle": "Manage and track all your content",
+    "eyebrow": "Library",
+    "subtitle": "Manage and track all your content.",
+    "emptyTitle": "No articles yet",
+    "noMatchTitle": "No results",
     "stats": {
       "total": "Total",
       "published": "Published",
@@ -363,7 +370,14 @@
   },
   "ideas": {
     "title": "Idea generator",
-    "subtitle": "Let AI suggest relevant topics for you",
+    "eyebrow": "Ideas",
+    "subtitle": "Let AI suggest relevant topics for your content.",
+    "emptyTitle": "No ideas yet",
+    "actions": {
+      "copy": "Copy title",
+      "like": "Interesting idea",
+      "dislike": "Not relevant"
+    },
     "configTitle": "Generation settings",
     "configDescription": "Set your parameters to get tailored suggestions",
     "mainKeyword": "Main keyword",
@@ -518,7 +532,9 @@
   },
   "settings": {
     "title": "Settings",
-    "subTitle": "Manage your account and preferences",
+    "eyebrow": "Account",
+    "subTitle": "Manage your account and preferences.",
+    "passwordDescription": "Update your password regularly to keep your account secure.",
     "tabs": {
       "profile": "Profile",
       "preferences": "Preferences",
@@ -592,10 +608,11 @@
     },
     "preferences": {
       "title": "App preferences",
-      "description": "Customize your experience",
+      "description": "Customize your experience.",
       "language": "Interface language",
       "timezone": "Timezone",
       "aiSettings": "Default AI settings",
+      "aiDescription": "Defaults used when generating new content.",
       "defaultTone": "Default tone of voice",
       "defaultWords": "Default word count",
       "darkMode": "Dark mode",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -262,7 +262,10 @@
   },
   "dashboard": {
     "title": "Bienvenue sur SEO Content AI",
-    "subtitle": "Voici un aperçu de votre activité",
+    "eyebrow": "Tableau de bord",
+    "greeting": "Bonjour, {name}",
+    "greetingGeneric": "Bonjour",
+    "subtitle": "Voici un aperçu de votre activité de création de contenu.",
     "loading": "Chargement de votre tableau de bord...",
     "loadError": "Impossible de charger votre tableau de bord.",
     "stats": {
@@ -287,7 +290,8 @@
       "title": "Articles récents",
       "description": "Vos derniers contenus mis à jour",
       "seoScoreLabel": "Score SEO",
-      "empty": "Aucun article pour le moment. Commencez par générer une idée ou écrire dans l'éditeur.",
+      "emptyTitle": "Pas encore d'article",
+      "empty": "Commencez par générer une idée ou écrire votre premier article dans l'éditeur.",
       "status": {
         "published": "Publié",
         "draft": "Brouillon",
@@ -305,7 +309,10 @@
   },
   "history": {
     "title": "Historique des publications",
-    "subtitle": "Gérez et suivez tous vos contenus",
+    "eyebrow": "Bibliothèque",
+    "subtitle": "Gérez et suivez tous vos contenus.",
+    "emptyTitle": "Aucun article",
+    "noMatchTitle": "Aucun résultat",
     "stats": {
       "total": "Total",
       "published": "Publiés",
@@ -363,7 +370,14 @@
   },
   "ideas": {
     "title": "Générateur d'idées",
-    "subtitle": "Laissez l'IA vous suggérer des sujets pertinents",
+    "eyebrow": "Idées",
+    "subtitle": "Laissez l'IA vous suggérer des sujets pertinents pour vos contenus.",
+    "emptyTitle": "Aucune idée générée",
+    "actions": {
+      "copy": "Copier le titre",
+      "like": "Idée intéressante",
+      "dislike": "Idée non pertinente"
+    },
     "configTitle": "Configuration de la génération",
     "configDescription": "Définissez vos paramètres pour obtenir des suggestions personnalisées",
     "mainKeyword": "Mot-clé principal",
@@ -518,7 +532,9 @@
   },
   "settings": {
     "title": "Paramètres",
-    "subTitle": "Gérez votre compte et vos préférences",
+    "eyebrow": "Compte",
+    "subTitle": "Gérez votre compte et vos préférences.",
+    "passwordDescription": "Modifiez votre mot de passe régulièrement pour garder votre compte en sécurité.",
     "tabs": {
       "profile": "Profil",
       "preferences": "Préférences",
@@ -592,10 +608,11 @@
     },
     "preferences": {
       "title": "Préférences de l'application",
-      "description": "Personnalisez votre expérience utilisateur",
+      "description": "Personnalisez votre expérience utilisateur.",
       "language": "Langue de l'interface",
       "timezone": "Fuseau horaire",
       "aiSettings": "Paramètres IA par défaut",
+      "aiDescription": "Configuration utilisée par défaut lors de la génération de contenu.",
       "defaultTone": "Ton de voix par défaut",
       "defaultWords": "Nombre de mots par défaut",
       "darkMode": "Mode sombre",


### PR DESCRIPTION
## Résumé

Refonte complète du design et de l'UX de toutes les pages user-facing (`/`, `/auth`, `/dashboard`, `/history`, `/ideas`, `/settings`, `/editor`), en étendant le langage visuel de l'admin déjà validé (PR #25).

## Principe

- **Palette unique** : slate (surfaces) + **emerald** (accent unique, brand color). Plus de gradient bleu/violet criards.
- **Surfaces cohérentes** : `bg-slate-50 dark:bg-slate-950` page, `bg-white dark:bg-slate-900` card, `rounded-2xl` borders `border-slate-200 dark:border-slate-800`.
- **Hiérarchie typo** : eyebrow uppercase emerald, titre `text-2xl/3xl font-semibold tracking-tight`, body `text-slate-600 dark:text-slate-400`.
- **Ombres disciplinées** : `shadow-sm` repos, `hover:shadow-md` interactif. Plus de `shadow-2xl` partout.

## Livrables

### Design system `frontend/src/components/ui-kit/`
- `PageShell` — wrapper bg + padding cohérent
- `PageHeader` — eyebrow + titre + description + actions
- `StatCard` — KPI uniforme (label, valeur, icône badge coloré, 6 tones)
- `SectionCard` — card avec header + body, 4 niveaux de padding
- `EmptyState` — empty state avec icône, action et footer
- `StatusBadge` — pill statut unifié (12+ variants)

### Pages refondues
- **Landing `/`** : hero plus calme avec halo emerald, features cards uniformes, pricing emerald accent
- **Auth `/auth`** : fond slate-50/950 avec halos décoratifs subtils, card backdrop blur
- **Dashboard `/dashboard`** : greeting personnalisé, 4 KPI uniformes, charts harmonisés, articles récents avec hover
- **History `/history`** : 4 StatCards, filtres en header, liste avec divide-y, EmptyState cohérent
- **Ideas `/ideas`** : config + suggestions dans SectionCards, StatusBadge pour difficulté
- **Settings `/settings`** : tabs avec accent emerald, intégrations Notion/Google dans cards uniformes

### Layout
- **Sidebar** : item actif = barre verticale emerald 4px + bg-slate-800/80 subtil (au lieu de bg-emerald-500 fill plein)

### Editor
- Chrome (header bar) refait : StatusBadge + word count pill, boutons rounded-lg, publish en emerald
- TipTap et logique métier intacts

### i18n
- Ajout des nouvelles clés en FR + EN en lockstep (675 clés × 2)

## Test plan

- [x] npm run lint : aucune nouvelle erreur introduite (8 erreurs préexistantes acceptées)
- [x] Parité i18n FR ↔ EN (675 = 675)
- [ ] Smoke UI : chaque page en light + dark, FR + EN
- [ ] Sidebar : item actif, hover, logout
- [ ] Auth : login + signup + Google fonctionnent
- [ ] Dashboard : KPI + charts + recent articles fetchent OK
- [ ] History : filtres + suppression
- [ ] Ideas : génération + copy
- [ ] Settings : profile + password, intégrations, prefs

🤖 Generated with [Claude Code](https://claude.com/claude-code)